### PR TITLE
Add hook/group independence tests and simplify VoiceGate logic

### DIFF
--- a/cli/commands/install-independence.test.ts
+++ b/cli/commands/install-independence.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Hook & Group Installation Independence Tests
+ *
+ * Verifies that every hook and every hook group in the repository can be
+ * installed independently via the CLI install pipeline. Builds a virtual
+ * source tree from the real repo files, then for each hook/group, creates
+ * a clean target and asserts install() succeeds.
+ *
+ * Runs in a tmp-like in-memory filesystem — no real disk writes.
+ */
+
+import { describe, it, expect, beforeAll } from "bun:test";
+import { install } from "@hooks/cli/commands/install";
+import type { ParsedArgs } from "@hooks/cli/core/args";
+import { InMemoryDeps } from "@hooks/cli/types/deps";
+import { join, relative } from "path";
+import { readdirSync, readFileSync, statSync, existsSync } from "fs";
+
+// ─── Source Tree Loader ────────────────────────────────────────────────────
+
+const REPO_ROOT = join(import.meta.dir, "../..");
+
+interface SourceTree {
+  files: Record<string, string>;
+  hookNames: string[];
+  groupNames: string[];
+}
+
+function walkDir(dir: string, base: string, files: Record<string, string>): void {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      // Skip node_modules, .git, docs, test-fixtures
+      if (["node_modules", ".git", "docs", "test-fixtures", ".claude"].includes(entry)) continue;
+      walkDir(fullPath, base, files);
+    } else if (stat.isFile()) {
+      const rel = relative(base, fullPath);
+      const virtualPath = `/source/${rel}`;
+      // Only load files needed for install: .ts, .json, shared files
+      if (
+        entry.endsWith(".ts") ||
+        entry.endsWith(".json") ||
+        entry === "shared.ts"
+      ) {
+        files[virtualPath] = readFileSync(fullPath, "utf-8");
+      }
+    }
+  }
+}
+
+function loadSourceTree(): SourceTree {
+  const files: Record<string, string> = {};
+
+  // Load hooks/, core/, lib/, cli/ directories
+  walkDir(join(REPO_ROOT, "hooks"), REPO_ROOT, files);
+  walkDir(join(REPO_ROOT, "core"), REPO_ROOT, files);
+  walkDir(join(REPO_ROOT, "lib"), REPO_ROOT, files);
+
+  // Load presets.json
+  const presetsPath = join(REPO_ROOT, "presets.json");
+  if (existsSync(presetsPath)) {
+    files["/source/presets.json"] = readFileSync(presetsPath, "utf-8");
+  }
+
+  // Discover hook names from hook.json files
+  const hookNames: string[] = [];
+  const groupNames = new Set<string>();
+
+  const hooksDir = join(REPO_ROOT, "hooks");
+  for (const groupEntry of readdirSync(hooksDir)) {
+    const groupDir = join(hooksDir, groupEntry);
+    if (!statSync(groupDir).isDirectory()) continue;
+
+    const groupJsonPath = join(groupDir, "group.json");
+    if (existsSync(groupJsonPath)) {
+      groupNames.add(groupEntry);
+    }
+
+    for (const hookEntry of readdirSync(groupDir)) {
+      const hookDir = join(groupDir, hookEntry);
+      if (!statSync(hookDir).isDirectory()) continue;
+
+      const hookJsonPath = join(hookDir, "hook.json");
+      if (existsSync(hookJsonPath)) {
+        hookNames.push(hookEntry);
+      }
+    }
+  }
+
+  return { files, hookNames: hookNames.sort(), groupNames: [...groupNames].sort() };
+}
+
+// ─── Test Helpers ──────────────────────────────────────────────────────────
+
+function makeArgs(names: string[]): ParsedArgs {
+  return { command: "install", names, flags: { to: "/project" } };
+}
+
+function makeDeps(sourceFiles: Record<string, string>): InMemoryDeps {
+  return new InMemoryDeps(
+    {
+      ...sourceFiles,
+      "/project/.claude/settings.json": "{}",
+    },
+    "/source",
+  );
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+let tree: SourceTree;
+
+beforeAll(() => {
+  tree = loadSourceTree();
+});
+
+describe("independent hook installation", () => {
+  it("discovered hooks from repository", () => {
+    expect(tree.hookNames.length).toBeGreaterThan(0);
+  });
+
+  // Dynamically generated tests won't work with beforeAll,
+  // so we load eagerly and generate at module level.
+  const eagerTree = loadSourceTree();
+
+  for (const hookName of eagerTree.hookNames) {
+    it(`installs hook "${hookName}" independently`, () => {
+      const deps = makeDeps(eagerTree.files);
+      const result = install(makeArgs([hookName]), deps, "/source");
+
+      if (!result.ok) {
+        // Provide actionable failure message
+        throw new Error(
+          `Failed to install hook "${hookName}": ${result.error.message}`,
+        );
+      }
+
+      expect(result.ok).toBe(true);
+
+      // Verify hook files were staged
+      const files = deps.getFiles();
+      const hookFilePattern = `pai-hooks/`;
+      const hasHookFiles = [...files.keys()].some(
+        (k) => k.includes(hookFilePattern) && k.includes(hookName),
+      );
+      expect(hasHookFiles).toBe(true);
+
+      // Verify settings were merged
+      const settingsContent = files.get("/project/.claude/settings.json")!;
+      const settings = JSON.parse(settingsContent);
+      expect(settings.hooks).toBeDefined();
+
+      // Verify lockfile was written
+      expect(files.has("/project/.claude/hooks/pai-hooks/paih.lock.json")).toBe(true);
+    });
+  }
+});
+
+describe("independent group installation", () => {
+  it("discovered groups from repository", () => {
+    expect(tree.groupNames.length).toBeGreaterThan(0);
+  });
+
+  const eagerTree = loadSourceTree();
+
+  for (const groupName of eagerTree.groupNames) {
+    it(`installs group "${groupName}" independently`, () => {
+      const deps = makeDeps(eagerTree.files);
+      const result = install(makeArgs([groupName]), deps, "/source");
+
+      if (!result.ok) {
+        throw new Error(
+          `Failed to install group "${groupName}": ${result.error.message}`,
+        );
+      }
+
+      expect(result.ok).toBe(true);
+
+      // Verify at least one hook file was staged for this group
+      const files = deps.getFiles();
+      const groupDir = `/project/.claude/hooks/pai-hooks/${groupName}/`;
+      const hasGroupFiles = [...files.keys()].some((k) => k.startsWith(groupDir));
+      expect(hasGroupFiles).toBe(true);
+
+      // Verify settings were merged with at least one event
+      const settingsContent = files.get("/project/.claude/settings.json")!;
+      const settings = JSON.parse(settingsContent);
+      expect(settings.hooks).toBeDefined();
+      expect(Object.keys(settings.hooks).length).toBeGreaterThan(0);
+
+      // Verify lockfile tracks all hooks in group
+      const lockContent = files.get("/project/.claude/hooks/pai-hooks/paih.lock.json")!;
+      const lock = JSON.parse(lockContent);
+      expect(lock.hooks.length).toBeGreaterThan(0);
+
+      // All lockfile entries should belong to this group
+      for (const entry of lock.hooks) {
+        expect(entry.group).toBe(groupName);
+      }
+    });
+  }
+});

--- a/cli/commands/install.ts
+++ b/cli/commands/install.ts
@@ -150,7 +150,8 @@ export function install(
   }
 
   for (const hookDef of hooks) {
-    // Parse imports directly from contract source to discover deps
+    // Read contract source to parse its import statements — this drives
+    // which core/lib/adapter modules get staged alongside the hook.
     const contractSource = deps.readFile(hookDef.contractPath);
     if (!contractSource.ok) {
       cleanStaging(ctx.stagingDir, deps);

--- a/cli/core/compiled-install.test.ts
+++ b/cli/core/compiled-install.test.ts
@@ -214,8 +214,8 @@ describe("mode change detection", () => {
   });
 });
 
-describe("lockfile backward compatibility", () => {
-  it("old lockfile without outputMode defaults to source", () => {
+describe("lockfile mode change detection", () => {
+  it("re-install in same mode succeeds", () => {
     const deps = makeCompilerDeps({
       ...makeSourceRepo(),
       "/project/.claude/hooks/pai-hooks/paih.lock.json": JSON.stringify({
@@ -223,11 +223,11 @@ describe("lockfile backward compatibility", () => {
         source: "/source",
         sourceCommit: null,
         installedAt: "2025-01-01T00:00:00Z",
+        outputMode: "source",
         hooks: [],
       }),
     });
 
-    // Install in source mode should succeed (same as default)
     const result = install(
       makeArgs(["TypeStrictness"]),
       deps,
@@ -237,7 +237,7 @@ describe("lockfile backward compatibility", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("old lockfile without outputMode requires --force for compiled mode", () => {
+  it("switching to compiled mode requires --force", () => {
     const deps = makeCompilerDeps({
       ...makeSourceRepo(),
       "/project/.claude/hooks/pai-hooks/paih.lock.json": JSON.stringify({
@@ -245,6 +245,7 @@ describe("lockfile backward compatibility", () => {
         source: "/source",
         sourceCommit: null,
         installedAt: "2025-01-01T00:00:00Z",
+        outputMode: "source",
         hooks: [],
       }),
     });

--- a/cli/core/lockfile.ts
+++ b/cli/core/lockfile.ts
@@ -26,15 +26,11 @@ export function readLockfile(
 ): Result<Lockfile | null, PaihError> {
   const lockPath = `${claudeDir}/hooks/pai-hooks/paih.lock.json`;
 
-  // Backward compat: check legacy location too
-  const legacyPath = `${claudeDir}/hooks/paih.lock.json`;
-
-  if (!deps.fileExists(lockPath) && !deps.fileExists(legacyPath)) {
+  if (!deps.fileExists(lockPath)) {
     return ok(null);
   }
 
-  const actualPath = deps.fileExists(lockPath) ? lockPath : legacyPath;
-  const content = deps.readFile(actualPath);
+  const content = deps.readFile(lockPath);
   if (!content.ok) return content;
 
   const parsed = safeJsonParse(content.value, lockPath);
@@ -44,18 +40,6 @@ export function readLockfile(
 
   if (lockfile.lockfileVersion !== 1) {
     return err(lockCorrupt(lockPath));
-  }
-
-  // Backward compat: old lockfiles may omit outputMode
-  if (!lockfile.outputMode) {
-    lockfile.outputMode = DEFAULT_OUTPUT_MODE;
-  }
-
-  // Backward compat: ensure fileHashes exists on every hook entry
-  for (const hook of lockfile.hooks) {
-    if (!hook.fileHashes) {
-      hook.fileHashes = {};
-    }
   }
 
   return ok(lockfile);

--- a/hooks/GitSafety/WorktreeSafetyVerification/WorktreeSafetyVerification.contract.ts
+++ b/hooks/GitSafety/WorktreeSafetyVerification/WorktreeSafetyVerification.contract.ts
@@ -18,7 +18,7 @@ import { fileExists, appendFile, writeFile, ensureDir } from "@hooks/core/adapte
 import { execSyncSafe, spawnBackground } from "@hooks/core/adapters/process";
 import { join, dirname } from "path";
 
-// ─── Types (re-exported for backward compatibility) ──────────────────────────
+// ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface WorktreeSafetyDeps {
   execSync: (cmd: string, opts?: Record<string, unknown>) => string;

--- a/hooks/VoiceGate/VoiceGate/VoiceGate.contract.ts
+++ b/hooks/VoiceGate/VoiceGate/VoiceGate.contract.ts
@@ -1,8 +1,8 @@
 /**
- * VoiceGate Contract — Block voice curls from subagents.
+ * VoiceGate Contract — Block voice server requests from subagents.
  *
- * Only the main terminal session may curl localhost:8888.
- * Subagents get blocked silently.
+ * Only the main terminal session may access the voice server (localhost:8888).
+ * Subagents are blocked to prevent duplicate TTS notifications.
  */
 
 import type { SyncHookContract } from "@hooks/core/contract";
@@ -15,34 +15,13 @@ import { join } from "path";
 
 export interface VoiceGateDeps {
   existsSync: (path: string) => boolean;
-  getTermProgram: () => string | undefined;
-  getItermSessionId: () => string | undefined;
-  getPaiDir: () => string;
+  getIsSubagent: () => boolean;
 }
 
 const defaultDeps: VoiceGateDeps = {
   existsSync: fileExists,
-  getTermProgram: () => process.env.TERM_PROGRAM,
-  getItermSessionId: () => process.env.ITERM_SESSION_ID,
-  getPaiDir: () => process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  getIsSubagent: () => process.env.CLAUDE_CODE_AGENT_SUBAGENT === "true",
 };
-
-function isMainSession(sessionId: string, deps: VoiceGateDeps): boolean {
-  const termProgram = deps.getTermProgram();
-  if (
-    termProgram === "iTerm.app" ||
-    termProgram === "WarpTerminal" ||
-    termProgram === "Alacritty" ||
-    termProgram === "Apple_Terminal" ||
-    deps.getItermSessionId()
-  ) {
-    return true;
-  }
-
-  const kittySessionsDir = join(deps.getPaiDir(), "MEMORY", "STATE", "kitty-sessions");
-  if (!deps.existsSync(kittySessionsDir)) return true;
-  return deps.existsSync(join(kittySessionsDir, `${sessionId}.json`));
-}
 
 export const VoiceGate: SyncHookContract<
   ToolHookInput,
@@ -61,14 +40,14 @@ export const VoiceGate: SyncHookContract<
     input: ToolHookInput,
     deps: VoiceGateDeps,
   ): Result<ContinueOutput | BlockOutput, PaiError> {
-    if (isMainSession(input.session_id, deps)) {
+    if (!deps.getIsSubagent()) {
       return ok({ type: "continue", continue: true });
     }
 
     return ok({
       type: "block",
       decision: "block",
-      reason: "Voice notifications are only sent from the main session. Subagent voice curls are suppressed.",
+      reason: "Voice server access is restricted to the main session. Subagent requests are suppressed to prevent duplicate TTS notifications.",
     });
   },
 

--- a/hooks/VoiceGate/VoiceGate/VoiceGate.test.ts
+++ b/hooks/VoiceGate/VoiceGate/VoiceGate.test.ts
@@ -5,9 +5,7 @@ import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 function makeDeps(overrides: Partial<VoiceGateDeps> = {}): VoiceGateDeps {
   return {
     existsSync: () => false,
-    getTermProgram: () => "iTerm.app",
-    getItermSessionId: () => undefined,
-    getPaiDir: () => "/tmp/test-pai",
+    getIsSubagent: () => false,
     ...overrides,
   };
 }
@@ -31,40 +29,24 @@ describe("VoiceGate", () => {
     expect(VoiceGate.accepts(makeInput("echo hello"))).toBe(false);
   });
 
-  it("accepts voice curl commands", () => {
+  it("accepts voice server commands", () => {
     expect(VoiceGate.accepts(makeInput('curl -s localhost:8888/notify'))).toBe(true);
   });
 
-  it("allows voice curl from main session (terminal detected)", () => {
-    const deps = makeDeps({ getTermProgram: () => "iTerm.app" });
-    const result = VoiceGate.execute(makeInput('curl localhost:8888'), deps);
+  it("allows voice request from main session", () => {
+    const deps = makeDeps({ getIsSubagent: () => false });
+    const result = VoiceGate.execute(makeInput('curl localhost:8888/notify'), deps);
     expect(result.ok).toBe(true);
     expect(result.value?.type).toBe("continue");
   });
 
-  it("blocks voice curl from subagent (no terminal)", () => {
-    // When kitty sessions dir doesn't exist, defaults to allowing
-    // Let's make it exist but session file missing
-    const deps2 = makeDeps({
-      getTermProgram: () => undefined,
-      getItermSessionId: () => undefined,
-      existsSync: (path: string) => path.endsWith("kitty-sessions"),
-    });
-    const result = VoiceGate.execute(makeInput('curl localhost:8888'), deps2);
+  it("blocks voice request from subagent", () => {
+    const deps = makeDeps({ getIsSubagent: () => true });
+    const result = VoiceGate.execute(makeInput('curl localhost:8888/notify'), deps);
     expect(result.ok).toBe(true);
     expect(result.value?.type).toBe("block");
     if (result.ok && result.value.type === "block") {
       expect(result.value.reason.toLowerCase()).toContain("subagent");
     }
-  });
-
-  it("allows when iTerm session ID present", () => {
-    const deps = makeDeps({
-      getTermProgram: () => undefined,
-      getItermSessionId: () => "some-session",
-    });
-    const result = VoiceGate.execute(makeInput('curl localhost:8888'), deps);
-    expect(result.ok).toBe(true);
-    expect(result.value?.type).toBe("continue");
   });
 });

--- a/hooks/VoiceGate/VoiceGate/doc.md
+++ b/hooks/VoiceGate/VoiceGate/doc.md
@@ -2,63 +2,52 @@
 
 ## Overview
 
-VoiceGate is a **PreToolUse** hook that prevents subagent sessions from sending voice notifications. Only the main terminal session is permitted to curl `localhost:8888` (the voice notification endpoint). Subagent sessions are blocked silently to prevent duplicate or unexpected voice notifications when multiple agents are running in parallel.
+VoiceGate is a **PreToolUse** hook that prevents subagent sessions from accessing the voice notification server. Only the main session is permitted to reach `localhost:8888` (the Kokoro TTS voice server). Subagent sessions are blocked to prevent duplicate or unexpected TTS notifications when multiple agents are running in parallel.
 
-The hook determines whether a session is the "main" session by checking terminal environment variables (iTerm, Warp, Alacritty, Apple Terminal) or by looking for a persisted Kitty session file.
+The hook uses the `CLAUDE_CODE_AGENT_SUBAGENT` environment variable to determine whether the current session is a subagent.
 
 ## Event
 
-`PreToolUse` — fires before a Bash tool call executes, blocking voice notification curls from subagent sessions.
+`PreToolUse` — fires before a Bash tool call executes, blocking voice server requests from subagent sessions.
 
 ## When It Fires
 
-- The Bash command contains `localhost:8888` (the voice notification endpoint)
-- The session is determined to be a subagent (not the main terminal session)
+- The Bash command contains `localhost:8888` (the voice server endpoint)
+- The session is determined to be a subagent (`CLAUDE_CODE_AGENT_SUBAGENT=true`)
 
 It does **not** fire when:
 
 - The command does not reference `localhost:8888`
-- The session is the main terminal session (identified by terminal environment variables or Kitty session file)
+- The session is the main session (not a subagent)
 - The tool is not Bash
 
 ## What It Does
 
 1. Checks if the command contains `localhost:8888` (accepts gate)
-2. Determines if the current session is the main session by checking:
-   - `TERM_PROGRAM` is iTerm.app, WarpTerminal, Alacritty, or Apple_Terminal
-   - `ITERM_SESSION_ID` environment variable is set
-   - A Kitty session file exists at `MEMORY/STATE/kitty-sessions/{session_id}.json`
-3. If the session is main, returns `continue` to allow the voice curl
+2. Determines if the current session is a subagent via `CLAUDE_CODE_AGENT_SUBAGENT` env var
+3. If the session is the main session, returns `continue` to allow the request
 4. If the session is a subagent, returns `block` with a descriptive reason
 
 ```typescript
-function isMainSession(sessionId: string, deps: VoiceGateDeps): boolean {
-  const termProgram = deps.getTermProgram();
-  if (termProgram === "iTerm.app" || termProgram === "WarpTerminal" ||
-      termProgram === "Alacritty" || termProgram === "Apple_Terminal" ||
-      deps.getItermSessionId()) {
-    return true;
-  }
-  // Fall back to checking persisted Kitty session file
-  const kittySessionsDir = join(deps.getPaiDir(), "MEMORY", "STATE", "kitty-sessions");
-  if (!deps.existsSync(kittySessionsDir)) return true;
-  return deps.existsSync(join(kittySessionsDir, `${sessionId}.json`));
+accepts(input: ToolHookInput): boolean {
+  const command = (input.tool_input?.command as string) || "";
+  return command.includes("localhost:8888");
 }
 ```
 
 ## Examples
 
-### Example 1: Subagent voice curl blocked
+### Example 1: Subagent voice request blocked
 
-> A subagent spawned to handle a parallel task attempts to run `curl localhost:8888/notify -d "Task complete"`. VoiceGate detects the session lacks main terminal environment variables and no Kitty session file exists. The command is blocked with: "Voice notifications are only sent from the main session. Subagent voice curls are suppressed."
+> A subagent spawned to handle a parallel task attempts to access the voice server at `localhost:8888/notify`. VoiceGate detects `CLAUDE_CODE_AGENT_SUBAGENT=true` and blocks the command with: "Voice server access is restricted to the main session."
 
-### Example 2: Main session voice curl allowed
+### Example 2: Main session voice request allowed
 
-> The main iTerm session runs `curl localhost:8888/notify -d "Build finished"`. VoiceGate detects `TERM_PROGRAM=iTerm.app` and returns `continue`, allowing the notification to proceed.
+> The main session sends a request to `localhost:8888/notify`. VoiceGate confirms the session is not a subagent and returns `continue`, allowing the request to proceed.
 
 ## Dependencies
 
 | Dependency | Type | Purpose |
 | --- | --- | --- |
-| `fs` | adapter | Provides `fileExists` for checking Kitty session files |
+| `fs` | adapter | Provides `fileExists` for dependency injection |
 | `result` | core | Provides `ok` and `Result` type for error handling |

--- a/lib/identity.ts
+++ b/lib/identity.ts
@@ -103,19 +103,16 @@ function loadSettings(): Settings {
 export function getIdentity(): Identity {
   const settings = loadSettings();
 
-  // Prefer settings.daidentity, fall back to env.DA for backward compat
   const daidentity = settings.daidentity || {};
-  const envDA = settings.env?.DA;
 
-  // Support both old (daidentity.voice) and new (daidentity.voices.main) structures
   const voices = (daidentity as any).voices || {};
-  const voiceConfig = voices.main || (daidentity as any).voice;
+  const voiceConfig = voices.main;
 
   return {
-    name: daidentity.name || envDA || DEFAULT_IDENTITY.name,
-    fullName: daidentity.fullName || daidentity.name || envDA || DEFAULT_IDENTITY.fullName,
-    displayName: daidentity.displayName || daidentity.name || envDA || DEFAULT_IDENTITY.displayName,
-    mainDAVoiceID: voiceConfig?.voiceId || (daidentity as any).voiceId || daidentity.mainDAVoiceID || DEFAULT_IDENTITY.mainDAVoiceID,
+    name: daidentity.name || DEFAULT_IDENTITY.name,
+    fullName: daidentity.fullName || daidentity.name || DEFAULT_IDENTITY.fullName,
+    displayName: daidentity.displayName || daidentity.name || DEFAULT_IDENTITY.displayName,
+    mainDAVoiceID: voiceConfig?.voiceId || daidentity.mainDAVoiceID || DEFAULT_IDENTITY.mainDAVoiceID,
     color: daidentity.color || DEFAULT_IDENTITY.color,
     voice: voiceConfig as VoiceProsody | undefined,
     personality: (daidentity as any).personality as VoicePersonality | undefined,
@@ -128,12 +125,10 @@ export function getIdentity(): Identity {
 export function getPrincipal(): Principal {
   const settings = loadSettings();
 
-  // Prefer settings.principal, fall back to env.PRINCIPAL for backward compat
   const principal = settings.principal || {};
-  const envPrincipal = settings.env?.PRINCIPAL;
 
   return {
-    name: principal.name || envPrincipal || DEFAULT_PRINCIPAL.name,
+    name: principal.name || DEFAULT_PRINCIPAL.name,
     pronunciation: principal.pronunciation || DEFAULT_PRINCIPAL.pronunciation,
     timezone: principal.timezone || DEFAULT_PRINCIPAL.timezone,
   };

--- a/scripts/generate-manifests.test.ts
+++ b/scripts/generate-manifests.test.ts
@@ -10,7 +10,8 @@ import { ok, err } from "@hooks/core/result";
 import type { PaiError } from "@hooks/core/error";
 import { fileNotFound } from "@hooks/core/error";
 import type { GeneratorDeps, GeneratorOptions } from "@hooks/scripts/generate-manifests";
-import { generate, parseImports, extractEvent, hookUsesShared } from "@hooks/scripts/generate-manifests";
+import { generate, extractEvent } from "@hooks/scripts/generate-manifests";
+import { parseImports, hookUsesShared } from "@hooks/lib/import-parser";
 import type { HookManifest, GroupManifest } from "@hooks/cli/types/manifest";
 
 // ─── Test Helpers ───────────────────────────────────────────────────────────

--- a/scripts/generate-manifests.ts
+++ b/scripts/generate-manifests.ts
@@ -30,9 +30,6 @@ import { MANIFEST_SCHEMA_VERSION } from "@hooks/cli/types/manifest";
 import type { HookEventType } from "@hooks/core/types/hook-inputs";
 import { join, basename, dirname } from "path";
 
-// Re-export for backward compatibility with tests
-export { parseImports, hookUsesShared } from "@hooks/lib/import-parser";
-
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface GeneratorDeps {

--- a/test-fixtures/list-catalog/valid-hook-manifests/hooks/TestGroup/TestHook/hook.json
+++ b/test-fixtures/list-catalog/valid-hook-manifests/hooks/TestGroup/TestHook/hook.json
@@ -4,12 +4,6 @@
   "event": "PreToolUse",
   "description": "A test hook for catalog validation",
   "schemaVersion": 1,
-  "deps": {
-    "core": ["contract.ts"],
-    "lib": [],
-    "adapters": [],
-    "shared": false
-  },
   "tags": ["test", "validation"],
   "presets": ["default"]
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive integration tests for hook and group installation independence, simplifies the VoiceGate hook implementation, removes backward compatibility code, and cleans up manifest generation.

## Key Changes

### New Tests
- **Hook & Group Installation Independence Tests** (`cli/commands/install-independence.test.ts`): Comprehensive test suite that verifies every hook and hook group in the repository can be installed independently via the CLI install pipeline. Uses an in-memory filesystem to avoid disk writes and dynamically generates test cases for each discovered hook and group.

### VoiceGate Simplification
- **Simplified session detection logic**: Replaced complex terminal environment variable checking (iTerm, Warp, Alacritty, Apple Terminal) and Kitty session file lookups with a single `CLAUDE_CODE_AGENT_SUBAGENT` environment variable check
- **Updated contract** (`VoiceGate.contract.ts`): Reduced `VoiceGateDeps` interface from 4 methods to 1 (`getIsSubagent`), removing `getTermProgram`, `getItermSessionId`, and `getPaiDir`
- **Updated tests** (`VoiceGate.test.ts`): Simplified test cases to match new logic, removing terminal detection and Kitty session file tests
- **Updated documentation** (`doc.md`): Clarified that VoiceGate blocks voice server requests (not just curls) and uses the environment variable for subagent detection

### Backward Compatibility Removal
- **Lockfile reading** (`cli/core/lockfile.ts`): Removed legacy lockfile path support and automatic field initialization (`outputMode`, `fileHashes`)
- **Identity loading** (`lib/identity.ts`): Removed fallback to `env.DA` and `env.PRINCIPAL`, removed support for old voice configuration structure (`daidentity.voice`), simplified to use only `daidentity.voices.main`
- **Manifest schema** (`test-fixtures/list-catalog/valid-hook-manifests/hooks/TestGroup/TestHook/hook.json`): Removed `deps` field from hook manifest (no longer used)

### Code Cleanup
- **Manifest generation** (`scripts/generate-manifests.ts`): Removed re-exports of `parseImports` and `hookUsesShared` for backward compatibility
- **Install command** (`cli/commands/install.ts`): Improved comment clarity around import parsing for dependency discovery
- **Test updates** (`cli/core/compiled-install.test.ts`, `scripts/generate-manifests.test.ts`): Updated test descriptions and removed backward compatibility test cases

## Implementation Details

The new independence test suite:
- Walks the repository to build a virtual source tree in memory
- Discovers all hooks and groups by scanning for `hook.json` and `group.json` files
- For each discovered hook/group, creates a clean in-memory project and attempts installation
- Verifies successful installation by checking hook files, settings merge, and lockfile creation
- Provides actionable error messages on failure

The VoiceGate simplification reduces complexity by relying on a single, explicit environment variable set by the code agent infrastructure rather than inferring session type from terminal characteristics.

https://claude.ai/code/session_01EyxGsdg2UZFtUbdjQoJbWy