### PR TITLE
fix: resolve all 8 TypeScript compilation errors

### DIFF
--- a/hooks/CanaryHook/CanaryHook/CanaryHook.contract.ts
+++ b/hooks/CanaryHook/CanaryHook/CanaryHook.contract.ts
@@ -1,7 +1,8 @@
 import type { SyncHookContract } from "@hooks/core/contract";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
-import type { Result, PaiError } from "@hooks/core/result";
+import type { Result } from "@hooks/core/result";
+import type { PaiError } from "@hooks/core/error";
 import { ok } from "@hooks/core/result";
 import { appendFile, ensureDir } from "@hooks/core/adapters/fs";
 import { execSyncSafe } from "@hooks/core/adapters/process";

--- a/hooks/DuplicationDetection/DuplicationIndexBuilder/DuplicationIndexBuilder.test.ts
+++ b/hooks/DuplicationDetection/DuplicationIndexBuilder/DuplicationIndexBuilder.test.ts
@@ -189,7 +189,7 @@ describe("DuplicationIndexBuilderContract", () => {
       const output = unwrap(DuplicationIndexBuilderContract.execute(input, deps));
 
       expect(output.continue).toBe(true);
-      expect((output as Record<string, unknown>).additionalContext).toBeUndefined();
+      expect((output as unknown as Record<string, unknown>).additionalContext).toBeUndefined();
     });
 
     test("handles missing project root gracefully", () => {

--- a/hooks/DuplicationDetection/parser.ts
+++ b/hooks/DuplicationDetection/parser.ts
@@ -31,7 +31,7 @@ const NODE_TYPE_INDEX = new Map(TOP_NODE_TYPES.map((t, i) => [t, i]));
 export function buildFingerprint(nodeTypes: string[]): string {
   const counts = new Uint8Array(16);
   for (const t of nodeTypes) {
-    const idx = NODE_TYPE_INDEX.get(t);
+    const idx = NODE_TYPE_INDEX.get(t as typeof TOP_NODE_TYPES[number]);
     if (idx !== undefined && counts[idx] < 255) counts[idx]++;
   }
   return Array.from(counts).map((c) => c.toString(16).padStart(2, "0")).join("");

--- a/hooks/DuplicationDetection/research/adapters.ts
+++ b/hooks/DuplicationDetection/research/adapters.ts
@@ -42,7 +42,8 @@ export function sha256Short(content: string): string {
 export function parseTsSourceSafe(source: string, isTsx: boolean): Module | null {
   try {
     return parseSync(source, {
-      syntax: isTsx ? "tsx" : "typescript",
+      syntax: "typescript",
+      tsx: isTsx,
       target: "es2022",
     });
   } catch {

--- a/hooks/DuplicationDetection/research/parse.ts
+++ b/hooks/DuplicationDetection/research/parse.ts
@@ -14,6 +14,8 @@ import type {
   ImportDeclaration,
   TsType,
   Param,
+  BindingIdentifier,
+  Pattern,
 } from "@swc/core";
 import type { ParsedFile, ParsedFunction, ParamInfo } from "@tools/pattern-detector/types";
 import {
@@ -58,7 +60,7 @@ function makeLineMapper(source: string): (offset: number) => number {
   return (offset: number): number => {
     let lo = 0;
     let hi = lineStarts.length - 1;
-    while (lo < hi) {
+    for (let step = 0; step < 32 && lo < hi; step++) {
       const mid = (lo + hi + 1) >> 1;
       if (lineStarts[mid] <= offset) lo = mid;
       else hi = mid - 1;
@@ -76,13 +78,7 @@ const TYPE_PATTERN = /"type":"([^"]+)"/g;
 
 function collectNodeTypes(body: BlockStatement): string[] {
   const json = JSON.stringify(body);
-  const types: string[] = [];
-  let match: RegExpExecArray | null;
-  TYPE_PATTERN.lastIndex = 0;
-  while ((match = TYPE_PATTERN.exec(json)) !== null) {
-    types.push(match[1]);
-  }
-  return types;
+  return Array.from(json.matchAll(TYPE_PATTERN), (m) => m[1]);
 }
 
 // Structural keys preserved during normalization — everything else stripped
@@ -104,10 +100,14 @@ function typeToString(tsType: TsType | undefined | null): string | null {
   return tsType.type;
 }
 
+function isBindingIdentifier(pat: Pattern): pat is BindingIdentifier {
+  return pat.type === "Identifier" && "typeAnnotation" in pat;
+}
+
 function extractParams(params: Param[]): ParamInfo[] {
   return params.map((p, i) => ({
     index: i,
-    typeAnnotation: p.pat.type === "Identifier" && p.pat.typeAnnotation
+    typeAnnotation: isBindingIdentifier(p.pat) && p.pat.typeAnnotation
       ? typeToString(p.pat.typeAnnotation.typeAnnotation)
       : null,
   }));
@@ -159,10 +159,15 @@ function walkStatements(
         const arrow = init as ArrowFunctionExpression | FunctionExpression;
         const body = arrow.body;
         if (body && body.type === "BlockStatement") {
+          // ArrowFunctionExpression has Pattern[], FunctionExpression has Param[]
+          // Normalize Pattern[] to Param[] by wrapping bare patterns
+          const params: Param[] = arrow.params.map((p) =>
+            "pat" in p ? p as Param : { type: "Parameter" as const, pat: p, span: arrow.span, decorators: [] },
+          );
           const fn = extractFromFunction(
             name,
             body as BlockStatement,
-            arrow.params,
+            params,
             arrow.returnType?.typeAnnotation,
             ctx,
             arrow.span,

--- a/hooks/DuplicationDetection/research/variants/index-builder.ts
+++ b/hooks/DuplicationDetection/research/variants/index-builder.ts
@@ -37,7 +37,7 @@ function buildBodyFingerprint(nodeTypes: string[]): string {
   // Count occurrences of top-16 node types, clamp to 0-255, encode as hex
   const counts = new Uint8Array(16);
   for (const t of nodeTypes) {
-    const idx = NODE_TYPE_INDEX.get(t);
+    const idx = NODE_TYPE_INDEX.get(t as typeof TOP_NODE_TYPES[number]);
     if (idx !== undefined && counts[idx] < 255) counts[idx]++;
   }
   // Encode as 32-char hex string


### PR DESCRIPTION
## Summary
- Fix `PaiError` import path in CanaryHook (was `@hooks/core/result`, should be `@hooks/core/error`)
- Add intermediate `unknown` cast in DuplicationIndexBuilder test for `ContinueOutput` to `Record<string, unknown>`
- Cast `string` to node type union literal for `NODE_TYPE_INDEX.get()` in `parser.ts` and `index-builder.ts`
- Use `syntax: "typescript"` with `tsx: true` instead of invalid `syntax: "tsx"` in SWC adapter
- Add `BindingIdentifier` type guard for safe `typeAnnotation` access on `Pattern` union in `parse.ts`
- Normalize `Pattern[]` to `Param[]` when processing `ArrowFunctionExpression` params in `parse.ts`
- Replace pre-existing `while` loops with bounded `for` loop and `matchAll` in `parse.ts`

## Test plan
- [x] `bunx tsc --noEmit` passes with zero errors (was 8)
- [x] `bun test --filter DuplicationIndexBuilder` — all 20 tests pass
- [x] Pre-existing test failures in `dist/` are unrelated (missing compiled artifacts)

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple

Closes https://github.com/SaintPepsi/pai-hooks/issues/20