### PR TITLE
fix: detect platform for shell in process.ts exec (#31)

### DIFF
--- a/core/adapters/process.test.ts
+++ b/core/adapters/process.test.ts
@@ -1,6 +1,34 @@
-import { describe, it, expect } from "bun:test";
-import { exec, getEnv, execSyncSafe, spawnSyncSafe } from "./process";
+import { describe, it, expect, mock } from "bun:test";
+import { exec, shellForPlatform, getEnv, execSyncSafe, spawnSyncSafe } from "./process";
 import { ErrorCode } from "../error";
+
+// ─── shellForPlatform ────────────────────────────────────────────────────────
+
+describe("shellForPlatform", () => {
+  it("returns sh -c for linux", () => {
+    const [shell, flag] = shellForPlatform("linux");
+    expect(shell).toBe("sh");
+    expect(flag).toBe("-c");
+  });
+
+  it("returns sh -c for darwin", () => {
+    const [shell, flag] = shellForPlatform("darwin");
+    expect(shell).toBe("sh");
+    expect(flag).toBe("-c");
+  });
+
+  it("returns cmd.exe /c for win32", () => {
+    const [shell, flag] = shellForPlatform("win32");
+    expect(shell).toBe("cmd.exe");
+    expect(flag).toBe("/c");
+  });
+
+  it("defaults to sh -c for unknown platforms", () => {
+    const [shell, flag] = shellForPlatform("freebsd");
+    expect(shell).toBe("sh");
+    expect(flag).toBe("-c");
+  });
+});
 
 // ─── exec ────────────────────────────────────────────────────────────────────
 
@@ -29,6 +57,14 @@ describe("exec", () => {
     expect(r.ok).toBe(true);
     // /tmp may resolve to /private/tmp on macOS
     expect(r.value!.stdout.trim()).toMatch(/\/tmp$/);
+  });
+
+  it("uses platform parameter for shell selection", async () => {
+    // We can't truly test win32 on POSIX, but we verify the param is accepted
+    // and that the default (current platform) works
+    const r = await exec("echo platform-test", { platform: process.platform });
+    expect(r.ok).toBe(true);
+    expect(r.value!.stdout.trim()).toBe("platform-test");
   });
 });
 

--- a/core/adapters/process.ts
+++ b/core/adapters/process.ts
@@ -12,13 +12,23 @@ export interface ExecResult {
   exitCode: number;
 }
 
+/**
+ * Detect the correct shell and flag for the current platform.
+ * Returns `["cmd.exe", "/c"]` on Windows, `["sh", "-c"]` on POSIX.
+ */
+export function shellForPlatform(platform: string): [shell: string, flag: string] {
+  if (platform === "win32") return ["cmd.exe", "/c"];
+  return ["sh", "-c"];
+}
+
 export async function exec(
   cmd: string,
-  opts: { timeout?: number; cwd?: string } = {},
+  opts: { timeout?: number; cwd?: string; platform?: string } = {},
 ): Promise<Result<ExecResult, PaiError>> {
   return tryCatchAsync(
     async () => {
-      const proc = Bun.spawn(["sh", "-c", cmd], {
+      const [shell, flag] = shellForPlatform(opts.platform ?? process.platform);
+      const proc = Bun.spawn([shell, flag, cmd], {
         cwd: opts.cwd,
         stdout: "pipe",
         stderr: "pipe",


### PR DESCRIPTION
## Summary
- Added `shellForPlatform()` function that returns `["cmd.exe", "/c"]` on win32, `["sh", "-c"]` on POSIX
- Modified `exec()` to accept optional `platform` parameter in opts for testability
- 29 tests pass, 0 fail, 62 assertions

## Test plan
- [x] `bun test hooks/core/adapters/process` — 29 pass, 0 fail
- [x] `npx tsc --noEmit` — zero errors in changed files
- [x] `shellForPlatform("win32")` returns `["cmd.exe", "/c"]`
- [x] `shellForPlatform("linux")` returns `["sh", "-c"]`

Note: `cli/adapters/process.ts` has the same hardcoding but is out of scope for this issue.

Closes https://github.com/SaintPepsi/pai-hooks/issues/31

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple