### PR TITLE
fix: remove dead STALENESS_SECONDS and formatFindings exports (#59)

### DIFF
--- a/hooks/DuplicationDetection/shared.ts
+++ b/hooks/DuplicationDetection/shared.ts
@@ -264,15 +264,8 @@ export function checkFunctions(
 
 // ─── Output Formatting ──────────────────────────────────────────────────────
 
-export const STALENESS_SECONDS = 300;
-
 export function formatMatch(m: DuplicationMatch): string {
   const sigStr = m.signals.join("+");
   const score = (m.topScore * 100).toFixed(0);
   return `Similar: ${m.functionName} → ${m.targetFile}:${m.targetName} (${sigStr}, ${score}%)`;
-}
-
-export function formatFindings(matches: DuplicationMatch[], stale: boolean): string {
-  const prefix = stale ? "stale: " : "";
-  return matches.map((m) => `${prefix}${formatMatch(m)}`).join("\n");
 }


### PR DESCRIPTION
## Summary
- Removes unused `STALENESS_SECONDS` constant and `formatFindings` function from `shared.ts`
- Both exports had no importers after the staleness feature was removed
- `formatMatch` (still used) is preserved

## Test plan
- [ ] `grep -r "STALENESS_SECONDS\|formatFindings" hooks/DuplicationDetection/ --include="*.ts" | grep -v "shared.ts"` returns no results
- [ ] `bun test hooks/DuplicationDetection/` passes
- [ ] `npx tsc --noEmit` passes

Closes #59

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple