### PR TITLE
docs: document module-level cache assumption in shared.ts (#64)

### DIFF
--- a/hooks/DuplicationDetection/shared.ts
+++ b/hooks/DuplicationDetection/shared.ts
@@ -117,6 +117,8 @@ export function getArtifactsDir(projectRoot: string, branch?: string | null): st
 
 // ─── Index Loading ──────────────────────────────────────────────────────────
 
+// Module-level cache: safe because each hook invocation runs in a separate process.
+// If hooks ever run in-process (e.g. test harness), this cache would serve stale data.
 let cachedIndex: DuplicationIndex | null = null;
 let cachedIndexPath: string | null = null;
 


### PR DESCRIPTION
## Summary
- Adds comment documenting that the module-level index cache in shared.ts assumes per-process execution
- Each hook invocation is a separate process so the cache is safe, but this isn't obvious from the code

## Test plan
- [ ] No code changes — comment only

Closes #64

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple