### PR TITLE
cleanup: remove vestigial now() test manipulation (#65)

### DIFF
--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
@@ -206,16 +206,6 @@ export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: bo
     });
 
     test("blocks regardless of index age (no staleness bypass)", () => {
-      const indexContent = require("node:fs").readFileSync(INDEX_PATH, "utf-8") as string;
-      const index = JSON.parse(indexContent) as { builtAt: string };
-      const builtAtMs = new Date(index.builtAt).getTime();
-      const SIX_MINUTES_MS = 6 * 60 * 1000;
-
-      const deps: DuplicationCheckerDeps = {
-        ...mockDeps,
-        now: () => builtAtMs + SIX_MINUTES_MS,
-      };
-
       const realContent = require("node:fs").readFileSync(
         `${PAI_HOOKS_ROOT}/hooks/CodingStandards/CodingStandardsAdvisor/CodingStandardsAdvisor.contract.ts`,
         "utf-8",
@@ -225,8 +215,7 @@ export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: bo
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         realContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
-      // Staleness no longer bypasses blocking — always blocks with blocking=true
+      const output = unwrap(DuplicationCheckerContract.execute(input, mockDeps));
       expect(output.type).toBe("block");
     });
     test("continues instead of blocking when blocking config is false", () => {


### PR DESCRIPTION
## Summary
- Removes the `SIX_MINUTES_MS` / `now()` override from the "blocks regardless of index age" test
- This override was testing staleness bypass which no longer exists
- Test now uses default `mockDeps` — same assertion, less noise

## Test plan
- [ ] `bun test hooks/DuplicationDetection/DuplicationChecker/` — 14 pass, 4 pre-existing fail (unchanged)

Closes #65

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple