### PR TITLE
fix: wrap JSON.parse calls in DuplicationDetection with tryCatch (#63)

### DIFF
--- a/hooks/DuplicationDetection/DuplicationIndexBuilder/DuplicationIndexBuilder.contract.ts
+++ b/hooks/DuplicationDetection/DuplicationIndexBuilder/DuplicationIndexBuilder.contract.ts
@@ -18,7 +18,7 @@ import {
 } from "@hooks/core/adapters/fs";
 import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
-import { ok, type Result } from "@hooks/core/result";
+import { ok, tryCatch, type Result } from "@hooks/core/result";
 import type { HookInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import type { IndexBuilderDeps } from "@hooks/hooks/DuplicationDetection/index-builder-logic";
@@ -164,8 +164,12 @@ export const DuplicationIndexBuilderContract: SyncHookContract<
     const changedFile = isToolInput(input) ? getFilePath(input) : null;
     const existingJson = deps.readFile(indexPath);
 
-    if (existingJson && changedFile) {
-      const existing = JSON.parse(existingJson) as ReturnType<typeof buildIndex>;
+    const parseResult = existingJson
+      ? tryCatch(() => JSON.parse(existingJson) as ReturnType<typeof buildIndex>, () => null)
+      : null;
+    const existing = parseResult?.ok ? parseResult.value : null;
+
+    if (existing && changedFile) {
       const content = deps.indexBuilderDeps.readFile(changedFile);
       if (content) {
         index = updateIndexForFile(existing, changedFile, content, deps.indexBuilderDeps);
@@ -174,7 +178,7 @@ export const DuplicationIndexBuilderContract: SyncHookContract<
         index = updateIndexForFile(existing, changedFile, "", deps.indexBuilderDeps);
       }
     } else {
-      // No existing index or SessionStart — full rebuild
+      // No existing index, parse failed, or SessionStart — full rebuild
       index = buildIndex(projectRoot, deps.indexBuilderDeps);
     }
 

--- a/hooks/DuplicationDetection/shared.ts
+++ b/hooks/DuplicationDetection/shared.ts
@@ -8,6 +8,7 @@
  */
 
 import { execSyncSafe } from "@hooks/core/adapters/process";
+import { tryCatch } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { ExtractedFunction } from "@hooks/hooks/DuplicationDetection/parser";
 
@@ -124,7 +125,9 @@ export function loadIndex(indexPath: string, deps: SharedDeps): DuplicationIndex
   if (cachedIndex && cachedIndexPath === indexPath) return cachedIndex;
   const content = deps.readFile(indexPath);
   if (!content) return null;
-  const parsed = JSON.parse(content) as DuplicationIndex;
+  const parseResult = tryCatch(() => JSON.parse(content) as DuplicationIndex, () => null);
+  if (!parseResult.ok) return null;
+  const parsed = parseResult.value;
   if (!parsed.version || !parsed.entries) return null;
 
   // Branch isolation is now handled by directory structure (/tmp/pai/duplication/{hash}/{branch}/)


### PR DESCRIPTION
## Summary
- Wrapped `JSON.parse` in `shared.ts:loadIndex` with `tryCatch` — returns `null` on malformed JSON instead of throwing
- Wrapped `JSON.parse` in `DuplicationIndexBuilder.contract.ts` surgical update path with `tryCatch` — falls through to full rebuild on corrupted index
- No try-catch in business logic: uses `tryCatch` from `@hooks/core/result` per coding standards

## Test plan
- [x] `bun test hooks/DuplicationDetection/` — 456 pass, 4 pre-existing failures (unrelated ENOENT)
- [x] `npx tsc --noEmit` — no new errors

Closes #63

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple