### PR TITLE
refactor: deduplicate getFilePath() across 14 hooks (#68)

### DIFF
--- a/hooks/CodeQualityPipeline/CodeQualityBaseline/CodeQualityBaseline.contract.ts
+++ b/hooks/CodeQualityPipeline/CodeQualityBaseline/CodeQualityBaseline.contract.ts
@@ -17,6 +17,7 @@ import { getLanguageProfile, isScorableFile } from "@hooks/core/language-profile
 import { formatAdvisory, type QualityScore, scoreFile } from "@hooks/core/quality-scorer";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { extractSvelteScript, isSvelteFile } from "@hooks/lib/svelte-utils";
 
@@ -52,13 +53,6 @@ export interface CodeQualityBaselineDeps {
 
 const MIN_LINES = 50;
 const LOW_SCORE_THRESHOLD = 6.0;
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input === "object" && input.tool_input !== null) {
-    return (input.tool_input.file_path as string) ?? null;
-  }
-  return null;
-}
 
 function isTestFile(filePath: string): boolean {
   const name = filePath.split("/").pop() ?? "";

--- a/hooks/CodeQualityPipeline/CodeQualityGuard/CodeQualityGuard.contract.ts
+++ b/hooks/CodeQualityPipeline/CodeQualityGuard/CodeQualityGuard.contract.ts
@@ -23,6 +23,7 @@ import {
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import {
   defaultSignalLoggerDeps,
   logSignal,
@@ -70,13 +71,6 @@ export interface CodeQualityGuardDeps {
 }
 
 // ─── Pure Logic ──────────────────────────────────────────────────────────────
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input === "object" && input.tool_input !== null) {
-    return (input.tool_input.file_path as string) ?? null;
-  }
-  return null;
-}
 
 const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx)$/;
 const TEST_SUPPRESSED_CHECKS = new Set(["type-import-ratio", "options-object-width"]);

--- a/hooks/CodingStandards/CodingStandardsAdvisor/CodingStandardsAdvisor.contract.ts
+++ b/hooks/CodingStandards/CodingStandardsAdvisor/CodingStandardsAdvisor.contract.ts
@@ -21,6 +21,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   findAllViolations,
@@ -40,11 +41,6 @@ export interface CodingStandardsAdvisorDeps {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return (input.tool_input.file_path as string) ?? null;
-}
 
 // ─── Contract ────────────────────────────────────────────────────────────────
 

--- a/hooks/CodingStandards/CodingStandardsEnforcer/CodingStandardsEnforcer.contract.ts
+++ b/hooks/CodingStandards/CodingStandardsEnforcer/CodingStandardsEnforcer.contract.ts
@@ -24,6 +24,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   findAllViolations,
@@ -61,11 +62,6 @@ export interface CodingStandardsEnforcerDeps {
 }
 
 // ─── Pure Functions ──────────────────────────────────────────────────────────
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return (input.tool_input.file_path as string) ?? null;
-}
 
 /** For Write: returns the full file content. For Edit: returns null (handled separately). */
 function getWriteContent(input: ToolHookInput): string | null {

--- a/hooks/CodingStandards/TypeCheckVerifier/TypeCheckVerifier.contract.ts
+++ b/hooks/CodingStandards/TypeCheckVerifier/TypeCheckVerifier.contract.ts
@@ -16,6 +16,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   defaultSignalLoggerDeps,
@@ -234,13 +235,6 @@ function formatAdvisory(errors: TypeCheckError[], filePath: string): string {
 
 function isTypeCheckableFile(filePath: string): boolean {
   return /\.tsx?$/.test(filePath) || isSvelteFile(filePath);
-}
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input === "object" && input.tool_input !== null) {
-    return (input.tool_input.file_path as string) ?? null;
-  }
-  return null;
 }
 
 const defaultDeps: TypeCheckVerifierDeps = {

--- a/hooks/CodingStandards/TypeStrictness/TypeStrictness.contract.ts
+++ b/hooks/CodingStandards/TypeStrictness/TypeStrictness.contract.ts
@@ -13,6 +13,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 import {
@@ -129,11 +130,6 @@ function getNewContent(input: ToolHookInput): string | null {
   }
 
   return null;
-}
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return (input.tool_input.file_path as string) ?? null;
 }
 
 // ─── Lazy Unknown Detection ─────────────────────────────────────────────────

--- a/hooks/CodingStandards/WhileLoopGuard/WhileLoopGuard.contract.ts
+++ b/hooks/CodingStandards/WhileLoopGuard/WhileLoopGuard.contract.ts
@@ -20,6 +20,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -69,11 +70,6 @@ function stripCommentsAndStrings(code: string, filePath: string): string {
 /** Detect while/do...while syntax in stripped code. */
 function containsWhileLoop(strippedCode: string): boolean {
   return /\bwhile\b/.test(strippedCode);
-}
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return (input.tool_input.file_path as string) ?? null;
 }
 
 function getWriteContent(input: ToolHookInput): string | null {

--- a/hooks/ObligationStateMachines/CitationEnforcement.shared.ts
+++ b/hooks/ObligationStateMachines/CitationEnforcement.shared.ts
@@ -6,6 +6,7 @@
 import { join } from "node:path";
 import { fileExists as fsFileExists, readFile, writeFile } from "@hooks/core/adapters/fs";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -27,11 +28,6 @@ export function isResearchSkill(input: ToolHookInput): boolean {
   const toolInput = input.tool_input;
   if (typeof toolInput !== "object" || toolInput === null) return false;
   return (toolInput as Record<string, unknown>).skill === "Research";
-}
-
-export function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return ((input.tool_input as Record<string, unknown>).file_path as string) ?? null;
 }
 
 export function flagPath(stateDir: string): string {

--- a/hooks/ObligationStateMachines/CitationEnforcement/CitationEnforcement.contract.ts
+++ b/hooks/ObligationStateMachines/CitationEnforcement/CitationEnforcement.contract.ts
@@ -2,12 +2,12 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   type CitationEnforcementDeps,
   defaultDeps,
   flagPath,
-  getFilePath,
   remindedPath,
 } from "@hooks/hooks/ObligationStateMachines/CitationEnforcement.shared";
 import { pickNarrative } from "@hooks/lib/narrative-reader";

--- a/hooks/ObligationStateMachines/CitationTracker/CitationEnforcement.ts
+++ b/hooks/ObligationStateMachines/CitationTracker/CitationEnforcement.ts
@@ -16,6 +16,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 
@@ -39,11 +40,6 @@ function isResearchSkill(input: ToolHookInput): boolean {
   const toolInput = input.tool_input;
   if (typeof toolInput !== "object" || toolInput === null) return false;
   return (toolInput as Record<string, unknown>).skill === "Research";
-}
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return ((input.tool_input as Record<string, unknown>).file_path as string) ?? null;
 }
 
 function flagPath(stateDir: string): string {

--- a/hooks/ObligationStateMachines/DocObligationStateMachine.shared.ts
+++ b/hooks/ObligationStateMachines/DocObligationStateMachine.shared.ts
@@ -15,6 +15,7 @@ import { jsonParseFailed, type PaiError } from "@hooks/core/error";
 import { isScorableFile } from "@hooks/core/language-profiles";
 import { tryCatch, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import { defaultStderr, getSettingsPath } from "@hooks/lib/paths";
 
 // ─── Project Hook Deduplication ───────────────────────────────────────────────
@@ -69,11 +70,6 @@ export function isRelatedDoc(docPath: string, codePath: string): boolean {
   const docDir = dirname(docPath);
   const codeDir = dirname(codePath);
   return codeDir.startsWith(docDir) || docDir.startsWith(codeDir);
-}
-
-export function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return ((input.tool_input as Record<string, unknown>).file_path as string) ?? null;
 }
 
 export function pendingPath(stateDir: string, sessionId: string): string {

--- a/hooks/ObligationStateMachines/DocObligationTracker/DocObligationStateMachine.ts
+++ b/hooks/ObligationStateMachines/DocObligationTracker/DocObligationStateMachine.ts
@@ -24,6 +24,7 @@ import type { PaiError } from "@hooks/core/error";
 import { isScorableFile } from "@hooks/core/language-profiles";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { BlockOutput, ContinueOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 
@@ -74,11 +75,6 @@ function isRelatedDoc(docPath: string, codePath: string): boolean {
   const codeDir = dirname(codePath);
   // Doc in same directory or a subdirectory of the code's directory
   return codeDir.startsWith(docDir) || docDir.startsWith(codeDir);
-}
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return ((input.tool_input as Record<string, unknown>).file_path as string) ?? null;
 }
 
 function pendingPath(stateDir: string, sessionId: string): string {

--- a/hooks/ObligationStateMachines/DocObligationTracker/DocObligationTracker.contract.ts
+++ b/hooks/ObligationStateMachines/DocObligationTracker/DocObligationTracker.contract.ts
@@ -2,13 +2,13 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   type DocObligationDeps,
   type DocTrackerExcludeDeps,
   defaultDeps,
   defaultDocTrackerExcludeDeps,
-  getFilePath,
   isDocFile,
   isNonTestCodeFile,
   isRelatedDoc,

--- a/hooks/ObligationStateMachines/HookDocStateMachine.shared.ts
+++ b/hooks/ObligationStateMachines/HookDocStateMachine.shared.ts
@@ -18,6 +18,7 @@ import { readFile } from "@hooks/core/adapters/fs";
 import { jsonParseFailed } from "@hooks/core/error";
 import { tryCatch } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ObligationConfig, ObligationDeps } from "@hooks/lib/obligation-machine";
 import {
   createDefaultDeps,
@@ -144,12 +145,6 @@ export function isHookDocFile(filePath: string, docFileName: string): boolean {
 /** Extract the parent directory from a file path. */
 export function getHookDirFromPath(filePath: string): string {
   return dirname(filePath);
-}
-
-/** Extract file_path from a tool hook input. */
-export function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return ((input.tool_input as Record<string, unknown>).file_path as string) ?? null;
 }
 
 // ─── Section Validation ───────────────────────────────────────────────────────

--- a/hooks/ObligationStateMachines/HookDocTracker/HookDocTracker.contract.ts
+++ b/hooks/ObligationStateMachines/HookDocTracker/HookDocTracker.contract.ts
@@ -2,11 +2,11 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { projectHasHook } from "@hooks/hooks/ObligationStateMachines/DocObligationStateMachine.shared";
 import {
   defaultDeps,
-  getFilePath,
   getHookDirFromPath,
   isHookDocFile,
   isHookSourceFile,

--- a/hooks/ObligationStateMachines/TestObligationStateMachine.shared.ts
+++ b/hooks/ObligationStateMachines/TestObligationStateMachine.shared.ts
@@ -15,6 +15,7 @@ import { jsonParseFailed } from "@hooks/core/error";
 import { isScorableFile } from "@hooks/core/language-profiles";
 import { tryCatch } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import { defaultStderr, getSettingsPath } from "@hooks/lib/paths";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -80,11 +81,6 @@ export function extractTestedSourceFiles(command: string): string[] | null {
 /** Check if a pending file matches a tested source file (by ending match). */
 export function pendingMatchesSource(pendingFile: string, sourceFile: string): boolean {
   return pendingFile.endsWith(sourceFile) || pendingFile.endsWith(`/${sourceFile}`);
-}
-
-export function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return ((input.tool_input as Record<string, unknown>).file_path as string) ?? null;
 }
 
 export function getCommand(input: ToolHookInput): string | null {

--- a/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.ts
+++ b/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.ts
@@ -24,6 +24,7 @@ import type { PaiError } from "@hooks/core/error";
 import { isScorableFile } from "@hooks/core/language-profiles";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { BlockOutput, ContinueOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 
@@ -90,11 +91,6 @@ function extractTestedSourceFiles(command: string): string[] | null {
 /** Check if a pending file matches a tested source file (by ending match). */
 function pendingMatchesSource(pendingFile: string, sourceFile: string): boolean {
   return pendingFile.endsWith(sourceFile) || pendingFile.endsWith(`/${sourceFile}`);
-}
-
-function getFilePath(input: ToolHookInput): string | null {
-  if (typeof input.tool_input !== "object" || input.tool_input === null) return null;
-  return ((input.tool_input as Record<string, unknown>).file_path as string) ?? null;
 }
 
 function getCommand(input: ToolHookInput): string | null {

--- a/hooks/ObligationStateMachines/TestObligationTracker/TestObligationTracker.contract.ts
+++ b/hooks/ObligationStateMachines/TestObligationTracker/TestObligationTracker.contract.ts
@@ -2,13 +2,13 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   defaultDeps,
   defaultTrackerExcludeDeps,
   extractTestedSourceFiles,
   getCommand,
-  getFilePath,
   isNonTestCodeFile,
   isTestCommand,
   matchesExcludePattern,


### PR DESCRIPTION
## Summary
- Replaced 14 local `getFilePath()` copies with canonical import from `@hooks/lib/tool-input`
- Updated 4 contract files that imported `getFilePath` from shared modules to use canonical source instead
- 18 files changed, net -63 lines (18 insertions, 81 deletions)

## Test plan
- [x] `bun test hooks/CodingStandards/ hooks/CodeQualityPipeline/ hooks/ObligationStateMachines/` — 541 pass, 0 fail, 12 skip
- [x] `npx tsc --noEmit` — no new errors (pre-existing only)
- [x] `grep "function getFilePath" hooks/` — zero local declarations remain

Closes #68

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple