### PR TITLE
refactor: consolidate isSubagent() into lib/environment.ts (#70)

### DIFF
--- a/hooks/AlgorithmTracking/CheckAlgorithmVersion/CheckAlgorithmVersion.contract.ts
+++ b/hooks/AlgorithmTracking/CheckAlgorithmVersion/CheckAlgorithmVersion.contract.ts
@@ -11,6 +11,7 @@ import type { AsyncHookContract } from "@hooks/core/contract";
 import { ErrorCode, PaiError } from "@hooks/core/error";
 import { err, ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
+import { isSubagent } from "@hooks/lib/environment";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -79,18 +80,13 @@ function defaultWriteStateFile(homeDir: string, data: Record<string, unknown>): 
   writeFile(join(stateDir, "algorithm-update.json"), JSON.stringify(data));
 }
 
-function defaultIsSubagent(envGet: (key: string) => string | undefined): boolean {
-  const claudeProjectDir = envGet("CLAUDE_PROJECT_DIR") || "";
-  return claudeProjectDir.includes("/.claude/Agents/") || envGet("CLAUDE_AGENT_TYPE") !== undefined;
-}
-
 // ─── Contract ────────────────────────────────────────────────────────────────
 
 const defaultDeps: CheckAlgorithmVersionDeps = {
   getLocalVersion: () => defaultGetLocalVersion(process.env.HOME!),
   getUpstreamVersion: defaultGetUpstreamVersion,
   writeStateFile: (data) => defaultWriteStateFile(process.env.HOME!, data),
-  isSubagent: () => defaultIsSubagent((key) => process.env[key]),
+  isSubagent: () => isSubagent((k) => process.env[k]),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
   homeDir: process.env.HOME!,
 };

--- a/hooks/SessionFraming/BranchAwareness/BranchAwareness.contract.ts
+++ b/hooks/SessionFraming/BranchAwareness/BranchAwareness.contract.ts
@@ -13,6 +13,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
+import { isSubagent } from "@hooks/lib/environment";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -31,12 +32,7 @@ const defaultDeps: BranchAwarenessDeps = {
     if (!result.ok) return null;
     return result.value.trim() || null;
   },
-  isSubagent: () => {
-    const claudeProjectDir = process.env.CLAUDE_PROJECT_DIR || "";
-    return (
-      claudeProjectDir.includes("/.claude/Agents/") || process.env.CLAUDE_AGENT_TYPE !== undefined
-    );
-  },
+  isSubagent: () => isSubagent((k) => process.env[k]),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/SessionFraming/CheckVersion/CheckVersion.contract.ts
+++ b/hooks/SessionFraming/CheckVersion/CheckVersion.contract.ts
@@ -10,6 +10,7 @@ import type { AsyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
+import { isSubagent } from "@hooks/lib/environment";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -42,10 +43,7 @@ async function defaultGetLatestVersion(): Promise<Result<string, PaiError>> {
 const defaultDeps: CheckVersionDeps = {
   getCurrentVersion: defaultGetCurrentVersion,
   getLatestVersion: defaultGetLatestVersion,
-  isSubagent: () => {
-    const projectDir = process.env.CLAUDE_PROJECT_DIR || "";
-    return projectDir.includes("/.claude/Agents/") || process.env.CLAUDE_AGENT_TYPE !== undefined;
-  },
+  isSubagent: () => isSubagent((k) => process.env[k]),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/SessionFraming/LoadContext/LoadContext.contract.ts
+++ b/hooks/SessionFraming/LoadContext/LoadContext.contract.ts
@@ -14,6 +14,7 @@ import type { PaiError } from "@hooks/core/error";
 import { unknownError } from "@hooks/core/error";
 import { ok, type Result, tryCatch } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
+import { isSubagent } from "@hooks/lib/environment";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getDAName } from "@hooks/lib/identity";
 import { recordSessionStart } from "@hooks/lib/notifications";
@@ -439,12 +440,7 @@ const defaultDeps: LoadContextDeps = {
     });
     return r.ok ? r.value.stdout.trim() : new Date().toISOString();
   },
-  isSubagent: () => {
-    const claudeProjectDir = process.env.CLAUDE_PROJECT_DIR || "";
-    return (
-      claudeProjectDir.includes("/.claude/Agents/") || process.env.CLAUDE_AGENT_TYPE !== undefined
-    );
-  },
+  isSubagent: () => isSubagent((k) => process.env[k]),
   baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };

--- a/hooks/SessionFraming/StartupGreeting/StartupGreeting.contract.ts
+++ b/hooks/SessionFraming/StartupGreeting/StartupGreeting.contract.ts
@@ -12,6 +12,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
+import { isSubagent } from "@hooks/lib/environment";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { persistKittySession } from "@hooks/lib/tab-setter";
 
@@ -54,12 +55,7 @@ const defaultDeps: StartupGreetingDeps = {
     return result.value.stdout || null;
   },
   persistKittySession,
-  isSubagent: () => {
-    const claudeProjectDir = process.env.CLAUDE_PROJECT_DIR || "";
-    return (
-      claudeProjectDir.includes("/.claude/Agents/") || process.env.CLAUDE_AGENT_TYPE !== undefined
-    );
-  },
+  isSubagent: () => isSubagent((k) => process.env[k]),
   getEnv: (key) => process.env[key],
   fileExists,
   ensureDir,

--- a/hooks/VoiceGate/VoiceGate/VoiceGate.contract.ts
+++ b/hooks/VoiceGate/VoiceGate/VoiceGate.contract.ts
@@ -6,6 +6,7 @@
  */
 
 import { fileExists } from "@hooks/core/adapters/fs";
+import { isSubagent } from "@hooks/lib/environment";
 import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
@@ -19,7 +20,7 @@ export interface VoiceGateDeps {
 
 const defaultDeps: VoiceGateDeps = {
   existsSync: fileExists,
-  getIsSubagent: () => process.env.CLAUDE_CODE_AGENT_SUBAGENT === "true",
+  getIsSubagent: () => isSubagent((k) => process.env[k]),
 };
 
 export const VoiceGate: SyncHookContract<


### PR DESCRIPTION
## Summary
- Replace 6 inline `isSubagent` implementations with canonical `isSubagent(getEnv)` from `@hooks/lib/environment`
- Canonical function combines all three detection methods: `CLAUDE_PROJECT_DIR`, `CLAUDE_AGENT_TYPE`, `CLAUDE_CODE_AGENT_SUBAGENT`
- Accepts `getEnv` parameter (no direct `process.env` access) — compliant with coding standards
- Updated: CheckVersion, LoadContext, StartupGreeting, BranchAwareness, CheckAlgorithmVersion, VoiceGate

## Test plan
- [x] `npx tsc --noEmit` — no new errors (pre-existing only)
- [x] `bun test` — 3317 pass, 6 pre-existing failures, 12 skip

Closes #70

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple