### PR TITLE
refactor: replace 25 inlined getPaiDir() calls with lib/paths import (#71)

### DIFF
--- a/hooks/AlgorithmTracking/AlgorithmTracker/AlgorithmTracker.contract.ts
+++ b/hooks/AlgorithmTracking/AlgorithmTracker/AlgorithmTracker.contract.ts
@@ -14,6 +14,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import type {
   AlgorithmCriterion,
@@ -162,7 +163,7 @@ const defaultDeps: AlgorithmTrackerDeps = {
   fileExists,
   readJson,
   fetch: globalThis.fetch,
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
   voiceId: process.env.PAI_VOICE_ID || "pNInz6obpgDQGcFmaJgB",
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };

--- a/hooks/AlgorithmTracking/SessionAutoName/SessionAutoName.contract.ts
+++ b/hooks/AlgorithmTracking/SessionAutoName/SessionAutoName.contract.ts
@@ -13,6 +13,7 @@ import type { AsyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { UserPromptSubmitInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { inference } from "@pai/Tools/Inference";
 
@@ -339,7 +340,7 @@ const defaultDeps: SessionAutoNameDeps = {
   getCustomTitle: defaultGetCustomTitle,
   spawnSync: (cmd, opts) =>
     Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe", timeout: opts?.timeout }),
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/ArchitectureEscalation/ArchitectureEscalation/ArchitectureEscalation.contract.ts
+++ b/hooks/ArchitectureEscalation/ArchitectureEscalation/ArchitectureEscalation.contract.ts
@@ -13,6 +13,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 type FsReadJson = <T = unknown>(path: string) => Result<T, PaiError>;
@@ -111,7 +112,7 @@ export function buildWarningMessage(criterionId: string, failedAttempts: number)
 // ─── Contract ────────────────────────────────────────────────────────────────
 
 const defaultDeps: ArchEscalationDeps = {
-  getPaiDir: () => process.env.PAI_DIR ?? join(process.env.HOME!, ".claude"),
+  getPaiDir: () => getPaiDir(),
   now: () => Date.now(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
   fileExists,

--- a/hooks/CodeQualityPipeline/CodeQualityBaseline/CodeQualityBaseline.contract.ts
+++ b/hooks/CodeQualityPipeline/CodeQualityBaseline/CodeQualityBaseline.contract.ts
@@ -17,6 +17,7 @@ import { getLanguageProfile, isScorableFile } from "@hooks/core/language-profile
 import { formatAdvisory, type QualityScore, scoreFile } from "@hooks/core/quality-scorer";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { extractSvelteScript, isSvelteFile } from "@hooks/lib/svelte-utils";
@@ -88,7 +89,7 @@ const defaultDeps: CodeQualityBaselineDeps = {
   scoreFile,
   formatAdvisory,
   getTimestamp: () => new Date().toISOString(),
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/CodeQualityPipeline/SessionQualityReport/SessionQualityReport.contract.ts
+++ b/hooks/CodeQualityPipeline/SessionQualityReport/SessionQualityReport.contract.ts
@@ -13,6 +13,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getLocalComponents } from "@hooks/lib/time";
 
@@ -132,7 +133,7 @@ const defaultDeps: SessionQualityReportDeps = {
   writeFile,
   ensureDir,
   getLocalComponents,
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/CodingStandards/CodingStandardsEnforcer/CodingStandardsEnforcer.contract.ts
+++ b/hooks/CodingStandards/CodingStandardsEnforcer/CodingStandardsEnforcer.contract.ts
@@ -24,6 +24,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
@@ -152,7 +153,7 @@ function getExportDefaultExclusions(
 
 // ─── Contract ────────────────────────────────────────────────────────────────
 
-const baseDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
+const baseDir = getPaiDir();
 
 const defaultDeps: CodingStandardsEnforcerDeps = {
   readFile: (path: string): string | null => {

--- a/hooks/GitSafety/GitAutoSync/GitAutoSync.contract.ts
+++ b/hooks/GitSafety/GitAutoSync/GitAutoSync.contract.ts
@@ -21,6 +21,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getLocalTimestamp } from "@hooks/lib/time";
 
@@ -226,7 +227,7 @@ const defaultDeps: GitAutoSyncDeps = {
   dateNow: () => Date.now(),
   getTimestamp: getLocalTimestamp,
   get claudeDir() {
-    return process.env.PAI_DIR ?? join(process.env.HOME!, ".claude");
+    return getPaiDir();
   },
   get backupDir() {
     return join(this.claudeDir, ".backup");

--- a/hooks/IdentityBranding/ModeAnalytics/ModeAnalytics.contract.ts
+++ b/hooks/IdentityBranding/ModeAnalytics/ModeAnalytics.contract.ts
@@ -12,6 +12,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -30,7 +31,7 @@ export interface ModeAnalyticsDeps {
 const defaultDeps: ModeAnalyticsDeps = {
   execSyncSafe,
   stderr: (msg) => process.stderr.write(`${msg}\n`),
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
 };
 
 // ─── Contract ───────────────────────────────────────────────────────────────

--- a/hooks/IdentityBranding/UpdateCounts/UpdateCounts.contract.ts
+++ b/hooks/IdentityBranding/UpdateCounts/UpdateCounts.contract.ts
@@ -12,6 +12,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -26,7 +27,7 @@ export interface UpdateCountsDeps {
 
 const defaultDeps: UpdateCountsDeps = {
   spawnBackground,
-  hooksDir: join(process.env.PAI_DIR || join(process.env.HOME!, ".claude"), "pai-hooks"),
+  hooksDir: join(getPaiDir(), "pai-hooks"),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/LastResponseCache/LastResponseCache/LastResponseCache.contract.ts
+++ b/hooks/LastResponseCache/LastResponseCache/LastResponseCache.contract.ts
@@ -14,6 +14,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result, tryCatch } from "@hooks/core/result";
 import type { StopInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -89,7 +90,7 @@ const defaultDeps: LastResponseCacheDeps = {
   readFile,
   writeFile,
   stderr: (msg) => process.stderr.write(`${msg}\n`),
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
 };
 
 export const LastResponseCache: SyncHookContract<StopInput, SilentOutput, LastResponseCacheDeps> = {

--- a/hooks/LearningFeedback/LearningActioner/LearningActioner.contract.ts
+++ b/hooks/LearningFeedback/LearningActioner/LearningActioner.contract.ts
@@ -29,6 +29,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getISOTimestamp } from "@hooks/lib/time";
 
@@ -352,7 +353,7 @@ const defaultDeps: LearningActionerDeps = {
   stat,
   spawnBackground,
   getISOTimestamp,
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/ObligationStateMachines/CitationEnforcement.shared.ts
+++ b/hooks/ObligationStateMachines/CitationEnforcement.shared.ts
@@ -6,6 +6,7 @@
 import { join } from "node:path";
 import { fileExists as fsFileExists, readFile, writeFile } from "@hooks/core/adapters/fs";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -45,7 +46,7 @@ function getStateDir(baseDir: string): string {
 }
 
 export const defaultDeps: CitationEnforcementDeps = {
-  stateDir: getStateDir(process.env.PAI_DIR || join(process.env.HOME!, ".claude")),
+  stateDir: getStateDir(getPaiDir()),
   fileExists: (path: string) => fsFileExists(path),
   writeFlag: (path: string) => {
     writeFile(path, new Date().toISOString());

--- a/hooks/ObligationStateMachines/CitationTracker/CitationEnforcement.ts
+++ b/hooks/ObligationStateMachines/CitationTracker/CitationEnforcement.ts
@@ -16,6 +16,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
@@ -53,7 +54,7 @@ function remindedPath(stateDir: string): string {
 // ─── Default Deps ────────────────────────────────────────────────────────────
 
 function getStateDir(): string {
-  const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
+  const paiDir = getPaiDir();
   return join(paiDir, "MEMORY", "STATE", "citation");
 }
 

--- a/hooks/ObligationStateMachines/DocObligationStateMachine.shared.ts
+++ b/hooks/ObligationStateMachines/DocObligationStateMachine.shared.ts
@@ -16,7 +16,7 @@ import { isScorableFile } from "@hooks/core/language-profiles";
 import { tryCatch, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getFilePath } from "@hooks/lib/tool-input";
-import { defaultStderr, getSettingsPath } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir, getSettingsPath } from "@hooks/lib/paths";
 
 // ─── Project Hook Deduplication ───────────────────────────────────────────────
 
@@ -179,7 +179,7 @@ export const defaultDocTrackerExcludeDeps: DocTrackerExcludeDeps = {
 };
 
 export const defaultDeps: DocObligationDeps = {
-  stateDir: getStateDir(process.env.PAI_DIR || join(process.env.HOME!, ".claude")),
+  stateDir: getStateDir(getPaiDir()),
   fileExists: (path: string) => fsFileExists(path),
   readPending: (path: string) => {
     const result = readFile(path);

--- a/hooks/ObligationStateMachines/DocObligationTracker/DocObligationStateMachine.ts
+++ b/hooks/ObligationStateMachines/DocObligationTracker/DocObligationStateMachine.ts
@@ -24,6 +24,7 @@ import type { PaiError } from "@hooks/core/error";
 import { isScorableFile } from "@hooks/core/language-profiles";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 import type { BlockOutput, ContinueOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
@@ -116,7 +117,7 @@ are already documented elsewhere or the obligation was a false positive).
 // ─── Default Deps ────────────────────────────────────────────────────────────
 
 function getStateDir(): string {
-  const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
+  const paiDir = getPaiDir();
   return join(paiDir, "MEMORY", "STATE", "doc-obligation");
 }
 

--- a/hooks/ObligationStateMachines/SpotCheckReview/SpotCheckReview.contract.ts
+++ b/hooks/ObligationStateMachines/SpotCheckReview/SpotCheckReview.contract.ts
@@ -11,6 +11,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { BlockOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { projectHasHook } from "@hooks/hooks/ObligationStateMachines/DocObligationStateMachine.shared";
 
@@ -63,9 +64,9 @@ Review for: bugs, security issues, missing error handling, code quality, and adh
 // ─── Default Deps ─────────────────────────────────────────────────────────────
 
 const defaultDeps: SpotCheckReviewDeps = {
-  paiDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  paiDir: getPaiDir(),
   stateDir: join(
-    process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+    getPaiDir(),
     "MEMORY",
     "STATE",
     "spot-check",

--- a/hooks/ObligationStateMachines/SpotCheckReview/SpotCheckReview.ts
+++ b/hooks/ObligationStateMachines/SpotCheckReview/SpotCheckReview.ts
@@ -22,6 +22,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { BlockOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { projectHasHook } from "@hooks/hooks/ObligationStateMachines/DocObligationStateMachine.shared";
 
@@ -73,7 +74,7 @@ Review for: bugs, security issues, missing error handling, code quality, and adh
 // ─── Default Deps ─────────────────────────────────────────────────────────────
 
 function getStateDir(): string {
-  const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
+  const paiDir = getPaiDir();
   return join(paiDir, "MEMORY", "STATE", "spot-check");
 }
 
@@ -126,7 +127,7 @@ export const SpotCheckReview: SyncHookContract<
 
   accepts(_input: StopInput): boolean {
     if (projectHasHook("SpotCheckReview")) return false;
-    const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
+    const paiDir = getPaiDir();
     if (process.cwd() === paiDir) return false;
     return true;
   },

--- a/hooks/ObligationStateMachines/TestObligationStateMachine.shared.ts
+++ b/hooks/ObligationStateMachines/TestObligationStateMachine.shared.ts
@@ -16,7 +16,7 @@ import { isScorableFile } from "@hooks/core/language-profiles";
 import { tryCatch } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getCommand, getFilePath } from "@hooks/lib/tool-input";
-import { defaultStderr, getSettingsPath } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir, getSettingsPath } from "@hooks/lib/paths";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -184,7 +184,7 @@ export const defaultTrackerExcludeDeps: TestTrackerExcludeDeps = {
 };
 
 export const defaultDeps: TestObligationDeps = {
-  stateDir: getStateDir(process.env.PAI_DIR || join(process.env.HOME!, ".claude")),
+  stateDir: getStateDir(getPaiDir()),
   fileExists: (path: string) => fsFileExists(path),
   readPending: (path: string) => {
     const result = readJson<unknown>(path);

--- a/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.ts
+++ b/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.ts
@@ -24,6 +24,7 @@ import type { PaiError } from "@hooks/core/error";
 import { isScorableFile } from "@hooks/core/language-profiles";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import { getCommand, getFilePath } from "@hooks/lib/tool-input";
 import type { BlockOutput, ContinueOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
@@ -155,7 +156,7 @@ function hasTestFile(sourcePath: string, fileExists: (path: string) => boolean):
 // ─── Default Deps ────────────────────────────────────────────────────────────
 
 function getStateDir(): string {
-  const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
+  const paiDir = getPaiDir();
   return join(paiDir, "MEMORY", "STATE", "test-obligation");
 }
 

--- a/hooks/SecurityValidator/PermissionPromptLogger/PermissionPromptLogger.contract.ts
+++ b/hooks/SecurityValidator/PermissionPromptLogger/PermissionPromptLogger.contract.ts
@@ -18,6 +18,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { PermissionRequestInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -58,7 +59,7 @@ function summarizeToolInput(toolInput: Record<string, unknown>): string {
 const defaultDeps: PermissionPromptLoggerDeps = {
   appendFile,
   ensureDir,
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/SecurityValidator/SecurityValidator/SecurityValidator.contract.ts
+++ b/hooks/SecurityValidator/SecurityValidator/SecurityValidator.contract.ts
@@ -14,6 +14,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import { type PaiError, securityBlock as securityBlockError } from "@hooks/core/error";
 import { err, ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import type { AskOutput, BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 
@@ -392,7 +393,7 @@ const defaultDeps: SecurityValidatorDeps = {
   safeRegexTest,
   createRegex,
   homedir: () => process.env.HOME || "/",
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/SessionFraming/LoadContext/LoadContext.contract.ts
+++ b/hooks/SessionFraming/LoadContext/LoadContext.contract.ts
@@ -14,6 +14,7 @@ import type { PaiError } from "@hooks/core/error";
 import { unknownError } from "@hooks/core/error";
 import { ok, type Result, tryCatch } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import { isSubagent } from "@hooks/lib/environment";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getDAName } from "@hooks/lib/identity";
@@ -441,7 +442,7 @@ const defaultDeps: LoadContextDeps = {
     return r.ok ? r.value.stdout.trim() : new Date().toISOString();
   },
   isSubagent: () => isSubagent((k) => process.env[k]),
-  baseDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  baseDir: getPaiDir(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 

--- a/hooks/SessionFraming/StartupGreeting/StartupGreeting.contract.ts
+++ b/hooks/SessionFraming/StartupGreeting/StartupGreeting.contract.ts
@@ -12,6 +12,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
+import { getPaiDir } from "@hooks/lib/paths";
 import { isSubagent } from "@hooks/lib/environment";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { persistKittySession } from "@hooks/lib/tab-setter";
@@ -35,12 +36,12 @@ export interface StartupGreetingDeps {
 
 const defaultDeps: StartupGreetingDeps = {
   readSettings: () => {
-    const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
+    const paiDir = getPaiDir();
     const settingsPath = join(paiDir, "settings.json");
     return readJson<Record<string, unknown>>(settingsPath);
   },
   runBanner: () => {
-    const paiDir = process.env.PAI_DIR || join(process.env.HOME!, ".claude");
+    const paiDir = getPaiDir();
     const bannerPath = join(paiDir, "PAI/Tools/Banner.ts");
     const result = spawnSyncSafe("bun", ["run", bannerPath], {
       encoding: "utf-8",
@@ -60,7 +61,7 @@ const defaultDeps: StartupGreetingDeps = {
   fileExists,
   ensureDir,
   writeFile,
-  paiDir: process.env.PAI_DIR || join(process.env.HOME!, ".claude"),
+  paiDir: getPaiDir(),
   stderr: (msg) => process.stderr.write(`${msg}\n`),
 };
 


### PR DESCRIPTION
## Summary
- Replace all inline `process.env.PAI_DIR || join(process.env.HOME!, ".claude")` patterns with canonical `getPaiDir()` from `@hooks/lib/paths`
- 23 files updated across 11 hook groups
- Net change: +50 -29 lines (added imports, removed inline expressions)

## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [x] `bun test` — 3341 pass, 4 pre-existing failures, 12 skip
- [x] Zero remaining inline PAI_DIR patterns in non-test hook files

Closes #71

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple