### PR TITLE
fix: wrap JSON.parse in narrative-reader with tryCatch (#79)

### DIFF
--- a/lib/narrative-reader.ts
+++ b/lib/narrative-reader.ts
@@ -8,6 +8,7 @@
  */
 
 import { join } from "node:path";
+import { tryCatch } from "@hooks/core/result";
 import {
   fileExists as adapterFileExists,
   readFile as adapterReadFile,
@@ -41,11 +42,13 @@ function parseEntries(content: string): NarrativeEntry[] {
   return content
     .split("\n")
     .filter((line) => line.trim().length > 0)
-    .map((line) => {
-      const parsed = JSON.parse(line);
-      return { message: String(parsed.message), score: Number(parsed.score) };
-    })
-    .filter((e) => e.message && [1, 2, 3].includes(e.score));
+    .flatMap((line) => {
+      const result = tryCatch(() => JSON.parse(line) as Record<string, unknown>, () => null);
+      if (!result.ok) return [];
+      const parsed = result.value;
+      const entry = { message: String(parsed.message), score: Number(parsed.score) };
+      return entry.message && [1, 2, 3].includes(entry.score) ? [entry] : [];
+    });
 }
 
 function pickRandom<T>(items: T[]): T {


### PR DESCRIPTION
## Summary
- Wrapped `JSON.parse` in `parseEntries()` with `tryCatch` from `@hooks/core/result`
- Malformed JSONL lines are silently skipped instead of crashing the hook
- Uses `flatMap` to filter out failed parses in a single pass

## Test plan
- [x] `bun test lib/narrative-reader` — 8 pass, 0 fail
- [x] `npx tsc --noEmit` — no new errors

Closes #79

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple