### PR TITLE
fix: add stderr warnings when SecurityValidator patterns fail to load (#77)

### DIFF
--- a/hooks/SecurityValidator/SecurityValidator/SecurityValidator.contract.ts
+++ b/hooks/SecurityValidator/SecurityValidator/SecurityValidator.contract.ts
@@ -277,13 +277,22 @@ function loadPatterns(deps: SecurityValidatorDeps): PatternsConfig {
     : deps.fileExists(systemPath)
       ? systemPath
       : null;
-  if (!patternsPath) return EMPTY_PATTERNS;
+  if (!patternsPath) {
+    deps.stderr("[SecurityValidator] WARNING: No security patterns file found — all validation bypassed");
+    return EMPTY_PATTERNS;
+  }
 
   const result = deps.readFile(patternsPath);
-  if (!result.ok) return EMPTY_PATTERNS;
+  if (!result.ok) {
+    deps.stderr(`[SecurityValidator] WARNING: Failed to read ${patternsPath} — all validation bypassed`);
+    return EMPTY_PATTERNS;
+  }
 
   const parsed = deps.safeParseYaml(result.value);
-  if (!parsed) return EMPTY_PATTERNS;
+  if (!parsed) {
+    deps.stderr(`[SecurityValidator] WARNING: Failed to parse ${patternsPath} — all validation bypassed`);
+    return EMPTY_PATTERNS;
+  }
   return parsed as PatternsConfig;
 }
 


### PR DESCRIPTION
## Summary
- `loadPatterns()` now emits `WARNING` to stderr on all three fail-open paths:
  - Missing patterns file (neither user nor system YAML found)
  - File read failure
  - YAML parse failure
- Previously these failed silently, bypassing all security validation with no indication

## Test plan
- [x] `bun test hooks/SecurityValidator/` — 88 pass, 0 fail
- [x] `npx tsc --noEmit` — no new errors

Closes #77

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple