### PR TITLE
docs: document node:path exemption from raw import rule (#80)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Contracts use narrowed types from `core/contract.ts`:
 
 ## Coding Standards
 
-- No raw Node builtins — use adapters from `core/adapters/`
+- No raw Node builtins — use adapters from `core/adapters/` (`node:path` is exempt — pure functions, no I/O)
 - No try-catch in business logic — use `Result<T, PaiError>` pipelines
 - No direct `process.env` outside `defaultDeps`
 - Use `@hooks/*` path aliases, not relative imports

--- a/lib/coding-standards-checks.ts
+++ b/lib/coding-standards-checks.ts
@@ -56,6 +56,7 @@ export function stripStringLiterals(line: string): string {
 
 // ─── Patterns ────────────────────────────────────────────────────────────────
 
+// node:path is intentionally exempt — pure functions, no I/O side effects
 export const RAW_BUILTIN_PATTERNS: ReadonlyArray<{ regex: RegExp; module: string }> = [
   { regex: /^\s*import\b.*from\s+["']fs["']/, module: "fs" },
   { regex: /^\s*import\b.*from\s+["']node:fs["']/, module: "node:fs" },


### PR DESCRIPTION
## Summary
- Updated CLAUDE.md coding standards: `node:path` is explicitly exempt from the "no raw Node builtins" rule (pure functions, no I/O)
- Added comment to `RAW_BUILTIN_PATTERNS` in `lib/coding-standards-checks.ts` documenting the intentional exemption
- No code behavior change — `node:path` was already absent from the enforcer's pattern list

## Test plan
- [x] Documentation-only change, no tests needed
- [x] Verified `node:path` is not in `RAW_BUILTIN_PATTERNS` (already exempt in code)

Closes #80

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple