### PR TITLE
refactor: adopt defaultStderr from lib/paths.ts across 60 hooks (#81)

### DIFF
--- a/hooks/AgentLifecycle/AgentExecutionGuard/AgentExecutionGuard.contract.ts
+++ b/hooks/AgentLifecycle/AgentExecutionGuard/AgentExecutionGuard.contract.ts
@@ -9,6 +9,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContextOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -25,7 +26,7 @@ const FAST_MODELS = ["haiku"];
 // ─── Contract ────────────────────────────────────────────────────────────────
 
 const defaultDeps: AgentExecutionGuardDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const AgentExecutionGuard: SyncHookContract<

--- a/hooks/AgentLifecycle/shared.ts
+++ b/hooks/AgentLifecycle/shared.ts
@@ -16,7 +16,7 @@ import {
 import { jsonParseFailed, type PaiError } from "@hooks/core/error";
 import type { Result } from "@hooks/core/result";
 import { tryCatch } from "@hooks/core/result";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -49,7 +49,7 @@ export const defaultDeps: AgentLifecycleDeps = {
   readDir: (path) => readDir(path) as Result<string[], PaiError>,
   removeFile,
   getAgentsDir: () => join(getPaiDir(), "MEMORY", "STATE", "agents"),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   now: () => new Date(),
 };
 

--- a/hooks/AlgorithmTracking/AlgorithmTracker/AlgorithmTracker.contract.ts
+++ b/hooks/AlgorithmTracking/AlgorithmTracker/AlgorithmTracker.contract.ts
@@ -15,7 +15,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import type {
   AlgorithmCriterion,
@@ -166,7 +166,7 @@ const defaultDeps: AlgorithmTrackerDeps = {
   fetch: globalThis.fetch,
   baseDir: getPaiDir(),
   voiceId: process.env.PAI_VOICE_ID || "pNInz6obpgDQGcFmaJgB",
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const AlgorithmTracker: SyncHookContract<

--- a/hooks/AlgorithmTracking/CheckAlgorithmVersion/CheckAlgorithmVersion.contract.ts
+++ b/hooks/AlgorithmTracking/CheckAlgorithmVersion/CheckAlgorithmVersion.contract.ts
@@ -13,6 +13,7 @@ import { err, ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import { isSubagent } from "@hooks/lib/environment";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -87,7 +88,7 @@ const defaultDeps: CheckAlgorithmVersionDeps = {
   getUpstreamVersion: defaultGetUpstreamVersion,
   writeStateFile: (data) => defaultWriteStateFile(process.env.HOME!, data),
   isSubagent: () => isSubagent((k) => process.env[k]),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   homeDir: process.env.HOME!,
 };
 

--- a/hooks/AlgorithmTracking/SessionAutoName/SessionAutoName.contract.ts
+++ b/hooks/AlgorithmTracking/SessionAutoName/SessionAutoName.contract.ts
@@ -13,7 +13,7 @@ import type { AsyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { UserPromptSubmitInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { inference } from "@pai/Tools/Inference";
 
@@ -341,7 +341,7 @@ const defaultDeps: SessionAutoNameDeps = {
   spawnSync: (cmd, opts) =>
     Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe", timeout: opts?.timeout }),
   baseDir: getPaiDir(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const SessionAutoName: AsyncHookContract<

--- a/hooks/ArchitectureEscalation/ArchitectureEscalation/ArchitectureEscalation.contract.ts
+++ b/hooks/ArchitectureEscalation/ArchitectureEscalation/ArchitectureEscalation.contract.ts
@@ -14,7 +14,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 type FsReadJson = <T = unknown>(path: string) => Result<T, PaiError>;
@@ -115,7 +115,7 @@ export function buildWarningMessage(criterionId: string, failedAttempts: number)
 const defaultDeps: ArchEscalationDeps = {
   getPaiDir: () => getPaiDir(),
   now: () => Date.now(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   fileExists,
   readJson,
   writeJson,

--- a/hooks/ArchitectureEscalation/SonnetDelegation/SonnetDelegation.contract.ts
+++ b/hooks/ArchitectureEscalation/SonnetDelegation/SonnetDelegation.contract.ts
@@ -12,6 +12,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -61,7 +62,7 @@ Independent mechanical steps may be dispatched in parallel.
 // ─── Default Deps ────────────────────────────────────────────────────────────
 
 const defaultDeps: SonnetDelegationDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/CodeQualityPipeline/CodeQualityBaseline/CodeQualityBaseline.contract.ts
+++ b/hooks/CodeQualityPipeline/CodeQualityBaseline/CodeQualityBaseline.contract.ts
@@ -17,7 +17,7 @@ import { getLanguageProfile, isScorableFile } from "@hooks/core/language-profile
 import { formatAdvisory, type QualityScore, scoreFile } from "@hooks/core/quality-scorer";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
@@ -91,7 +91,7 @@ const defaultDeps: CodeQualityBaselineDeps = {
   formatAdvisory,
   getTimestamp: () => new Date().toISOString(),
   baseDir: getPaiDir(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const CodeQualityBaseline: SyncHookContract<

--- a/hooks/CodeQualityPipeline/CodeQualityGuard/CodeQualityGuard.contract.ts
+++ b/hooks/CodeQualityPipeline/CodeQualityGuard/CodeQualityGuard.contract.ts
@@ -23,6 +23,7 @@ import {
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { getFilePath } from "@hooks/lib/tool-input";
 import {
@@ -116,7 +117,7 @@ const defaultDeps: CodeQualityGuardDeps = {
   formatAdvisory,
   formatDelta,
   signal: defaultSignalLoggerDeps,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const CodeQualityGuard: SyncHookContract<

--- a/hooks/CodeQualityPipeline/SessionQualityReport/SessionQualityReport.contract.ts
+++ b/hooks/CodeQualityPipeline/SessionQualityReport/SessionQualityReport.contract.ts
@@ -13,7 +13,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getLocalComponents } from "@hooks/lib/time";
 
@@ -134,7 +134,7 @@ const defaultDeps: SessionQualityReportDeps = {
   ensureDir,
   getLocalComponents,
   baseDir: getPaiDir(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const SessionQualityReport: SyncHookContract<

--- a/hooks/CodingStandards/BashWriteGuard/BashWriteGuard.contract.ts
+++ b/hooks/CodingStandards/BashWriteGuard/BashWriteGuard.contract.ts
@@ -15,6 +15,7 @@ import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getCommand } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 
@@ -56,7 +57,7 @@ function detectsWriteToTypeScript(command: string): boolean {
 // ─── Contract ────────────────────────────────────────────────────────────────
 
 const defaultDeps: BashWriteGuardDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const BashWriteGuard: SyncHookContract<

--- a/hooks/CodingStandards/CodingStandardsAdvisor/CodingStandardsAdvisor.contract.ts
+++ b/hooks/CodingStandards/CodingStandardsAdvisor/CodingStandardsAdvisor.contract.ts
@@ -23,6 +23,7 @@ import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   findAllViolations,
@@ -50,7 +51,7 @@ const defaultDeps: CodingStandardsAdvisorDeps = {
     const result = adapterReadFile(path);
     return result.ok ? result.value : null;
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const CodingStandardsAdvisor: SyncHookContract<

--- a/hooks/CodingStandards/CodingStandardsEnforcer/CodingStandardsEnforcer.contract.ts
+++ b/hooks/CodingStandards/CodingStandardsEnforcer/CodingStandardsEnforcer.contract.ts
@@ -24,7 +24,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
@@ -166,7 +166,7 @@ const defaultDeps: CodingStandardsEnforcerDeps = {
     return result.ok ? result.value : {};
   },
   signal: defaultSignalLoggerDeps,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   baseDir,
 };
 

--- a/hooks/CodingStandards/TypeCheckVerifier/TypeCheckVerifier.contract.ts
+++ b/hooks/CodingStandards/TypeCheckVerifier/TypeCheckVerifier.contract.ts
@@ -18,6 +18,7 @@ import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   defaultSignalLoggerDeps,
@@ -262,7 +263,7 @@ const defaultDeps: TypeCheckVerifierDeps = {
     };
   },
   signal: defaultSignalLoggerDeps,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const TypeCheckVerifier: SyncHookContract<

--- a/hooks/CodingStandards/TypeStrictness/TypeStrictness.contract.ts
+++ b/hooks/CodingStandards/TypeStrictness/TypeStrictness.contract.ts
@@ -15,6 +15,7 @@ import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 import {
@@ -248,7 +249,7 @@ function formatBlockMessage(violations: AnyViolation[], filePath: string): strin
 
 const defaultDeps: TypeStrictnessDeps = {
   signal: defaultSignalLoggerDeps,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const TypeStrictness: SyncHookContract<

--- a/hooks/CodingStandards/WhileLoopGuard/WhileLoopGuard.contract.ts
+++ b/hooks/CodingStandards/WhileLoopGuard/WhileLoopGuard.contract.ts
@@ -22,6 +22,7 @@ import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -109,7 +110,7 @@ const defaultDeps: WhileLoopGuardDeps = {
     const result = adapterReadFile(path);
     return result.ok ? result.value : null;
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const WhileLoopGuard: SyncHookContract<

--- a/hooks/CronStatusLine/CronCreate/CronCreate.contract.ts
+++ b/hooks/CronStatusLine/CronCreate/CronCreate.contract.ts
@@ -22,6 +22,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import {
   appendCronLog,
   type CronEntry,
@@ -79,7 +80,7 @@ const defaultDeps: CronCreateDeps = {
   readDir,
   removeFile,
   appendFile,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   getEnv: (key) => process.env[key],
   now: () => Date.now(),
 };

--- a/hooks/CronStatusLine/CronDelete/CronDelete.contract.ts
+++ b/hooks/CronStatusLine/CronDelete/CronDelete.contract.ts
@@ -23,6 +23,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import {
   appendCronLog,
   type CronFileDeps,
@@ -46,7 +47,7 @@ const defaultDeps: CronDeleteDeps = {
   readDir,
   removeFile,
   appendFile,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   getEnv: (key) => process.env[key],
 };
 

--- a/hooks/CronStatusLine/CronFire/CronFire.contract.ts
+++ b/hooks/CronStatusLine/CronFire/CronFire.contract.ts
@@ -30,6 +30,7 @@ import type { Result } from "@hooks/core/result";
 import { ok } from "@hooks/core/result";
 import type { UserPromptSubmitInput } from "@hooks/core/types/hook-inputs";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import { silent } from "@hooks/core/types/hook-outputs";
 import type { CronFileDeps, CronPathDeps } from "@hooks/hooks/CronStatusLine/shared";
 import { appendCronLog, readCronFile, writeCronFile } from "@hooks/hooks/CronStatusLine/shared";
@@ -50,7 +51,7 @@ const defaultDeps: CronFireDeps = {
   readDir,
   removeFile,
   appendFile,
-  stderr: (msg: string) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   getEnv: (key: string) => process.env[key],
   now: () => Date.now(),
 };

--- a/hooks/CronStatusLine/CronPrune/CronPrune.contract.ts
+++ b/hooks/CronStatusLine/CronPrune/CronPrune.contract.ts
@@ -24,6 +24,7 @@ import { jsonParseFailed } from "@hooks/core/error";
 import { ok, type Result, tryCatch } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type {
   CronFileDeps,
   CronPathDeps,
@@ -155,7 +156,7 @@ const defaultDeps: CronPruneDeps = {
   },
   removeFile,
   appendFile,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   now: () => Date.now(),
   stat: fsStat,
 };

--- a/hooks/CronStatusLine/CronSessionEnd/CronSessionEnd.contract.ts
+++ b/hooks/CronStatusLine/CronSessionEnd/CronSessionEnd.contract.ts
@@ -23,6 +23,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import {
   appendCronLog,
   type CronFileDeps,
@@ -45,7 +46,7 @@ const defaultDeps: CronSessionEndDeps = {
   readDir,
   removeFile,
   appendFile,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   getEnv: (key) => process.env[key],
 };
 

--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
@@ -18,7 +18,7 @@ import {
   fileExists,
   readJson,
 } from "@hooks/core/adapters/fs";
-import { getSettingsPath } from "@hooks/lib/paths";
+import { defaultStderr, getSettingsPath } from "@hooks/lib/paths";
 import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
@@ -78,7 +78,7 @@ const defaultDeps: DuplicationCheckerDeps = {
   ensureDir: (path: string): void => {
     adapterEnsureDir(path);
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   now: () => Date.now(),
   blocking: readBlockingConfig(),
 };

--- a/hooks/DuplicationDetection/DuplicationIndexBuilder/DuplicationIndexBuilder.contract.ts
+++ b/hooks/DuplicationDetection/DuplicationIndexBuilder/DuplicationIndexBuilder.contract.ts
@@ -21,6 +21,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, tryCatch, type Result } from "@hooks/core/result";
 import type { HookInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import type { IndexBuilderDeps } from "@hooks/hooks/DuplicationDetection/index-builder-logic";
 import { buildIndex, updateIndexForFile } from "@hooks/hooks/DuplicationDetection/index-builder-logic";
@@ -108,7 +109,7 @@ const defaultDeps: DuplicationIndexBuilderDeps = {
     const result = adapterStat(path);
     return result.ok ? { mtimeMs: result.value.mtimeMs } : null;
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   now: () => Date.now(),
   findProjectRoot: defaultFindProjectRoot,
   cwd: () => process.cwd(),

--- a/hooks/ExecutionEvidence/ExecutionEvidenceVerifier/ExecutionEvidenceVerifier.contract.ts
+++ b/hooks/ExecutionEvidence/ExecutionEvidenceVerifier/ExecutionEvidenceVerifier.contract.ts
@@ -16,6 +16,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import {
   buildReminder,
@@ -32,7 +33,7 @@ export interface ExecutionEvidenceVerifierDeps {
 // ─── Default Deps ────────────────────────────────────────────────────────────
 
 const defaultDeps: ExecutionEvidenceVerifierDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/GitSafety/ApprovalGate/ApprovalGate.contract.ts
+++ b/hooks/GitSafety/ApprovalGate/ApprovalGate.contract.ts
@@ -20,6 +20,7 @@ import {
   type ContinueOutput,
   continueOk,
 } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import {
   checkCiStatus,
   extractPrNumber,
@@ -69,7 +70,7 @@ function formatVerificationReminder(prNumber: number): string {
 
 const defaultDeps: ApprovalGateDeps = {
   exec: (cmd: string) => execSyncSafe(cmd, { timeout: 15_000 }),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/GitSafety/DestructiveDeleteGuard/DestructiveDeleteGuard.contract.ts
+++ b/hooks/GitSafety/DestructiveDeleteGuard/DestructiveDeleteGuard.contract.ts
@@ -28,6 +28,7 @@ import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getCommand } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { AskOutput, BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Artifact Allowlist ─────────────────────────────────────────────────────
@@ -222,7 +223,7 @@ function isArtifactDirCleanup(command: string): boolean {
 // ─── Contract ────────────────────────────────────────────────────────────────
 
 const defaultDeps: DestructiveDeleteGuardDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const DestructiveDeleteGuard: SyncHookContract<

--- a/hooks/GitSafety/GitAutoSync/GitAutoSync.contract.ts
+++ b/hooks/GitSafety/GitAutoSync/GitAutoSync.contract.ts
@@ -21,7 +21,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getLocalTimestamp } from "@hooks/lib/time";
 
@@ -232,7 +232,7 @@ const defaultDeps: GitAutoSyncDeps = {
   get backupDir() {
     return join(this.claudeDir, ".backup");
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/GitSafety/HookExecutePermission/HookExecutePermission.contract.ts
+++ b/hooks/GitSafety/HookExecutePermission/HookExecutePermission.contract.ts
@@ -12,6 +12,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 export interface HookExecutePermissionDeps {
@@ -25,7 +26,7 @@ function isHookFile(filePath: string): boolean {
 
 const defaultDeps: HookExecutePermissionDeps = {
   execSync: (cmd) => execSyncSafe(cmd, { timeout: 5000 }),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const HookExecutePermission: SyncHookContract<

--- a/hooks/GitSafety/IssueCreateGate/IssueCreateGate.contract.ts
+++ b/hooks/GitSafety/IssueCreateGate/IssueCreateGate.contract.ts
@@ -20,6 +20,7 @@ import {
   type ContinueOutput,
   continueOk,
 } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -57,7 +58,7 @@ function isIssueCreate(command: string): boolean {
 // ─── Default Deps ────────────────────────────────────────────────────────────
 
 const defaultDeps: IssueCreateGateDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/GitSafety/MergeGate/MergeGate.contract.ts
+++ b/hooks/GitSafety/MergeGate/MergeGate.contract.ts
@@ -20,6 +20,7 @@ import {
   type ContinueOutput,
   continueOk,
 } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import {
   checkCiStatus,
   checkReviewStatus,
@@ -74,7 +75,7 @@ function formatReviewBlockMessage(
 
 const defaultDeps: MergeGateDeps = {
   exec: (cmd: string) => execSyncSafe(cmd, { timeout: 15_000 }),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/GitSafety/ProtectedBranchGuard/ProtectedBranchGuard.contract.ts
+++ b/hooks/GitSafety/ProtectedBranchGuard/ProtectedBranchGuard.contract.ts
@@ -21,7 +21,7 @@ import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { getCommand } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
-import { getSettingsPath } from "@hooks/lib/paths";
+import { defaultStderr, getSettingsPath } from "@hooks/lib/paths";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -116,7 +116,7 @@ const defaultDeps: ProtectedBranchGuardDeps = {
       const r = readFile(p);
       return r.ok ? r.value : null;
     }),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ───────────────────────────────────────────────────────────────

--- a/hooks/GitSafety/RebaseGuard/RebaseGuard.contract.ts
+++ b/hooks/GitSafety/RebaseGuard/RebaseGuard.contract.ts
@@ -22,6 +22,7 @@ import {
   type ContinueOutput,
   continueOk,
 } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -91,7 +92,7 @@ function formatBlockMessage(command: string): string {
 // ─── Default Deps ───────────────────────────────────────────────────────────
 
 const defaultDeps: RebaseGuardDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ───────────────────────────────────────────────────────────────

--- a/hooks/GitSafety/WorktreeSafetyVerification/WorktreeSafetyVerification.contract.ts
+++ b/hooks/GitSafety/WorktreeSafetyVerification/WorktreeSafetyVerification.contract.ts
@@ -16,6 +16,7 @@ import type { PaiError } from "@hooks/core/error";
 import { map, ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -253,7 +254,7 @@ const defaultDeps: WorktreeSafetyDeps = {
   mkdirSync: (path: string) => {
     ensureDir(path);
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   cwd: () => process.cwd(),
 };
 

--- a/hooks/IdentityBranding/MapleBranding/MapleBranding.contract.ts
+++ b/hooks/IdentityBranding/MapleBranding/MapleBranding.contract.ts
@@ -11,6 +11,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 
@@ -23,7 +24,7 @@ export interface MapleBrandingDeps {
 // ─── Default Deps ────────────────────────────────────────────────────────────
 
 const defaultDeps: MapleBrandingDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Pure Logic ──────────────────────────────────────────────────────────────

--- a/hooks/IdentityBranding/ModeAnalytics/ModeAnalytics.contract.ts
+++ b/hooks/IdentityBranding/ModeAnalytics/ModeAnalytics.contract.ts
@@ -12,7 +12,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -30,7 +30,7 @@ export interface ModeAnalyticsDeps {
 
 const defaultDeps: ModeAnalyticsDeps = {
   execSyncSafe,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   baseDir: getPaiDir(),
 };
 

--- a/hooks/IdentityBranding/UpdateCounts/UpdateCounts.contract.ts
+++ b/hooks/IdentityBranding/UpdateCounts/UpdateCounts.contract.ts
@@ -12,7 +12,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -28,7 +28,7 @@ export interface UpdateCountsDeps {
 const defaultDeps: UpdateCountsDeps = {
   spawnBackground,
   hooksDir: join(getPaiDir(), "pai-hooks"),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const UpdateCounts: SyncHookContract<SessionEndInput, SilentOutput, UpdateCountsDeps> = {

--- a/hooks/KoordDaemon/AgentCompleteTracker/AgentCompleteTracker.contract.ts
+++ b/hooks/KoordDaemon/AgentCompleteTracker/AgentCompleteTracker.contract.ts
@@ -28,6 +28,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import { continueOk } from "@hooks/core/types/hook-outputs";
 import {
   defaultReadFileOrNull,
@@ -53,7 +54,7 @@ const defaultDeps: AgentCompleteTrackerDeps = {
   getEnv: (name) => process.env[name],
   safeFetch,
   getKoordConfig: () => readKoordConfig(defaultReadFileOrNull),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/KoordDaemon/AgentPrepromptInjector/AgentPrepromptInjector.contract.ts
+++ b/hooks/KoordDaemon/AgentPrepromptInjector/AgentPrepromptInjector.contract.ts
@@ -26,6 +26,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { ContinueOutput, UpdatedInputOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import { continueOk, updatedInput } from "@hooks/core/types/hook-outputs";
 import {
   defaultReadFileOrNull,
@@ -56,7 +57,7 @@ const defaultDeps: AgentPrepromptInjectorDeps = {
   readFile,
   getKoordConfig: () => readKoordConfig(defaultReadFileOrNull),
   getCwd: () => process.cwd(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/KoordDaemon/AgentSpawnTracker/AgentSpawnTracker.contract.ts
+++ b/hooks/KoordDaemon/AgentSpawnTracker/AgentSpawnTracker.contract.ts
@@ -26,6 +26,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import { continueOk } from "@hooks/core/types/hook-outputs";
 import {
   defaultReadFileOrNull,
@@ -53,7 +54,7 @@ const defaultDeps: AgentSpawnTrackerDeps = {
   getEnv: (name) => process.env[name],
   safeFetch,
   getKoordConfig: () => readKoordConfig(defaultReadFileOrNull),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/KoordDaemon/MessageQueueRelay/MessageQueueRelay.contract.ts
+++ b/hooks/KoordDaemon/MessageQueueRelay/MessageQueueRelay.contract.ts
@@ -21,6 +21,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import { continueOk } from "@hooks/core/types/hook-outputs";
 import { MQ_WATCHER_MARKER } from "@hooks/hooks/KoordDaemon/shared";
 
@@ -33,7 +34,7 @@ export interface MessageQueueRelayDeps {
 // ─── Default Deps ────────────────────────────────────────────────────────────
 
 const defaultDeps: MessageQueueRelayDeps = {
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/hooks/KoordDaemon/MessageQueueServer/MessageQueueServer.contract.ts
+++ b/hooks/KoordDaemon/MessageQueueServer/MessageQueueServer.contract.ts
@@ -22,6 +22,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import {
   defaultReadFileOrNull,
   getQueueDir,
@@ -64,7 +65,7 @@ const defaultDeps: MessageQueueServerDeps = {
       return false;
     }
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   getScriptPath: () => {
     // Resolve relative to this file's location → ../../scripts/mq-server.ts
     const hookDir = import.meta.dir;

--- a/hooks/KoordDaemon/SessionIdRegister/SessionIdRegister.contract.ts
+++ b/hooks/KoordDaemon/SessionIdRegister/SessionIdRegister.contract.ts
@@ -23,6 +23,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import { defaultReadFileOrNull, readKoordConfig } from "@hooks/hooks/KoordDaemon/shared";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -43,7 +44,7 @@ const defaultDeps: SessionIdRegisterDeps = {
   getEnv: (name) => process.env[name],
   safeFetch,
   getKoordConfig: () => readKoordConfig(defaultReadFileOrNull),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/LastResponseCache/LastResponseCache/LastResponseCache.contract.ts
+++ b/hooks/LastResponseCache/LastResponseCache/LastResponseCache.contract.ts
@@ -14,7 +14,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result, tryCatch } from "@hooks/core/result";
 import type { StopInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -89,7 +89,7 @@ function extractLastAssistantMessage(transcriptPath: string, deps: LastResponseC
 const defaultDeps: LastResponseCacheDeps = {
   readFile,
   writeFile,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
   baseDir: getPaiDir(),
 };
 

--- a/hooks/LearningFeedback/LearningActioner/LearningActioner.contract.ts
+++ b/hooks/LearningFeedback/LearningActioner/LearningActioner.contract.ts
@@ -29,7 +29,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionEndInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getISOTimestamp } from "@hooks/lib/time";
 
@@ -354,7 +354,7 @@ const defaultDeps: LearningActionerDeps = {
   spawnBackground,
   getISOTimestamp,
   baseDir: getPaiDir(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const LearningActioner: SyncHookContract<

--- a/hooks/LearningFeedback/RelationshipMemory/RelationshipMemory.contract.ts
+++ b/hooks/LearningFeedback/RelationshipMemory/RelationshipMemory.contract.ts
@@ -13,7 +13,7 @@ import { ok, type Result, tryCatch } from "@hooks/core/result";
 import type { StopInput } from "@hooks/core/types/hook-inputs";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getDAName, getPrincipalName } from "@hooks/lib/identity";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import { getLocalComponents } from "@hooks/lib/time";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -173,7 +173,7 @@ const defaultDeps: RelationshipMemoryDeps = {
   readTranscript: defaultReadTranscript,
   analyzeForRelationship: defaultAnalyzeForRelationship,
   writeNotes: defaultWriteNotes,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const RelationshipMemory: SyncHookContract<StopInput, SilentOutput, RelationshipMemoryDeps> =

--- a/hooks/ObligationStateMachines/CitationEnforcement.shared.ts
+++ b/hooks/ObligationStateMachines/CitationEnforcement.shared.ts
@@ -6,7 +6,7 @@
 import { join } from "node:path";
 import { fileExists as fsFileExists, readFile, writeFile } from "@hooks/core/adapters/fs";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -60,5 +60,5 @@ export const defaultDeps: CitationEnforcementDeps = {
   writeReminded: (path: string, files: string[]) => {
     writeFile(path, JSON.stringify(files));
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };

--- a/hooks/ObligationStateMachines/CitationTracker/CitationEnforcement.ts
+++ b/hooks/ObligationStateMachines/CitationTracker/CitationEnforcement.ts
@@ -16,7 +16,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
@@ -74,7 +74,7 @@ const defaultDeps: CitationEnforcementDeps = {
   writeReminded: (path: string, files: string[]) => {
     writeFile(path, JSON.stringify(files));
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract 1: CitationTracker ─────────────────────────────────────────────

--- a/hooks/ObligationStateMachines/DocObligationStateMachine.shared.ts
+++ b/hooks/ObligationStateMachines/DocObligationStateMachine.shared.ts
@@ -205,5 +205,5 @@ export const defaultDeps: DocObligationDeps = {
   writeReview: (path: string, content: string) => {
     writeFile(path, content);
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };

--- a/hooks/ObligationStateMachines/DocObligationTracker/DocObligationStateMachine.ts
+++ b/hooks/ObligationStateMachines/DocObligationTracker/DocObligationStateMachine.ts
@@ -24,7 +24,7 @@ import type { PaiError } from "@hooks/core/error";
 import { isScorableFile } from "@hooks/core/language-profiles";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import { getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
 import type { BlockOutput, ContinueOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
@@ -149,7 +149,7 @@ const defaultDeps: DocObligationDeps = {
   writeReview: (path: string, content: string) => {
     writeFile(path, content);
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract 1: DocObligationTracker ────────────────────────────────────────

--- a/hooks/ObligationStateMachines/SpotCheckReview/SpotCheckReview.contract.ts
+++ b/hooks/ObligationStateMachines/SpotCheckReview/SpotCheckReview.contract.ts
@@ -11,7 +11,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { BlockOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { projectHasHook } from "@hooks/hooks/ObligationStateMachines/DocObligationStateMachine.shared";
 
@@ -103,7 +103,7 @@ const defaultDeps: SpotCheckReviewDeps = {
   removeFlag: (path: string) => {
     removeFile(path);
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ─────────────────────────────────────────────────────────────────

--- a/hooks/ObligationStateMachines/SpotCheckReview/SpotCheckReview.ts
+++ b/hooks/ObligationStateMachines/SpotCheckReview/SpotCheckReview.ts
@@ -22,7 +22,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { BlockOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { projectHasHook } from "@hooks/hooks/ObligationStateMachines/DocObligationStateMachine.shared";
 
@@ -112,7 +112,7 @@ const defaultDeps: SpotCheckReviewDeps = {
   removeFlag: (path: string) => {
     removeFile(path);
   },
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ─────────────────────────────────────────────────────────────────

--- a/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.ts
+++ b/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.ts
@@ -24,6 +24,7 @@ import type { PaiError } from "@hooks/core/error";
 import { isScorableFile } from "@hooks/core/language-profiles";
 import { ok, type Result } from "@hooks/core/result";
 import type { StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import { getPaiDir } from "@hooks/lib/paths";
 import { getCommand, getFilePath } from "@hooks/lib/tool-input";
 import { continueOk } from "@hooks/core/types/hook-outputs";
@@ -161,7 +162,7 @@ function getStateDir(): string {
   return join(paiDir, "MEMORY", "STATE", "test-obligation");
 }
 
-const stderr = (msg: string) => process.stderr.write(`${msg}\n`);
+
 
 const defaultDeps: TestObligationDeps = {
   stateDir: getStateDir(),
@@ -170,7 +171,7 @@ const defaultDeps: TestObligationDeps = {
     const result = readJson<unknown>(path);
     if (!result.ok) {
       if (fsFileExists(path)) {
-        stderr(`[TestObligationTracker] corrupt state file, resetting: ${path}`);
+        defaultStderr(`[TestObligationTracker] corrupt state file, resetting: ${path}`);
       }
       return [];
     }
@@ -179,13 +180,13 @@ const defaultDeps: TestObligationDeps = {
   writePending: (path: string, files: string[]) => {
     const result = writeFile(path, JSON.stringify(files));
     if (!result.ok) {
-      stderr(`[TestObligationTracker] write failed: ${result.error.message}`);
+      defaultStderr(`[TestObligationTracker] write failed: ${result.error.message}`);
     }
   },
   removeFlag: (path: string) => {
     const result = removeFile(path);
     if (!result.ok) {
-      stderr(`[TestObligationTracker] remove failed: ${result.error.message}`);
+      defaultStderr(`[TestObligationTracker] remove failed: ${result.error.message}`);
     }
   },
   readBlockCount: (path: string) => {
@@ -197,16 +198,16 @@ const defaultDeps: TestObligationDeps = {
   writeBlockCount: (path: string, count: number) => {
     const result = writeFile(path, String(count));
     if (!result.ok) {
-      stderr(`[TestObligationTracker] write block count failed: ${result.error.message}`);
+      defaultStderr(`[TestObligationTracker] write block count failed: ${result.error.message}`);
     }
   },
   writeReview: (path: string, content: string) => {
     const result = writeFile(path, content);
     if (!result.ok) {
-      stderr(`[TestObligationTracker] write review failed: ${result.error.message}`);
+      defaultStderr(`[TestObligationTracker] write review failed: ${result.error.message}`);
     }
   },
-  stderr,
+  stderr: defaultStderr,
 };
 
 // ─── Contract 1: TestObligationTracker ───────────────────────────────────────

--- a/hooks/QuestionAnswered/QuestionAnswered/QuestionAnswered.contract.ts
+++ b/hooks/QuestionAnswered/QuestionAnswered/QuestionAnswered.contract.ts
@@ -10,6 +10,7 @@ import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import { readTabState, setTabState, stripPrefix } from "@hooks/lib/tab-setter";
 
 export interface QuestionAnsweredDeps {
@@ -23,7 +24,7 @@ const defaultDeps: QuestionAnsweredDeps = {
   setTabState,
   readTabState,
   stripPrefix,
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const QuestionAnswered: SyncHookContract<ToolHookInput, SilentOutput, QuestionAnsweredDeps> =

--- a/hooks/SecurityValidator/PermissionPromptLogger/PermissionPromptLogger.contract.ts
+++ b/hooks/SecurityValidator/PermissionPromptLogger/PermissionPromptLogger.contract.ts
@@ -18,7 +18,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { PermissionRequestInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -60,7 +60,7 @@ const defaultDeps: PermissionPromptLoggerDeps = {
   appendFile,
   ensureDir,
   baseDir: getPaiDir(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/SecurityValidator/SecurityValidator/SecurityValidator.contract.ts
+++ b/hooks/SecurityValidator/SecurityValidator/SecurityValidator.contract.ts
@@ -15,7 +15,7 @@ import { type PaiError, securityBlock as securityBlockError } from "@hooks/core/
 import { err, ok, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import type { AskOutput, BlockOutput, ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 
@@ -404,7 +404,7 @@ const defaultDeps: SecurityValidatorDeps = {
   createRegex,
   homedir: () => process.env.HOME || "/",
   baseDir: getPaiDir(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const SecurityValidator: SyncHookContract<

--- a/hooks/SessionFraming/BranchAwareness/BranchAwareness.contract.ts
+++ b/hooks/SessionFraming/BranchAwareness/BranchAwareness.contract.ts
@@ -15,6 +15,7 @@ import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import { isSubagent } from "@hooks/lib/environment";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -33,7 +34,7 @@ const defaultDeps: BranchAwarenessDeps = {
     return result.value.trim() || null;
   },
   isSubagent: () => isSubagent((k) => process.env[k]),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/SessionFraming/CheckVersion/CheckVersion.contract.ts
+++ b/hooks/SessionFraming/CheckVersion/CheckVersion.contract.ts
@@ -12,6 +12,7 @@ import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import { isSubagent } from "@hooks/lib/environment";
 import type { SilentOutput } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -44,7 +45,7 @@ const defaultDeps: CheckVersionDeps = {
   getCurrentVersion: defaultGetCurrentVersion,
   getLatestVersion: defaultGetLatestVersion,
   isSubagent: () => isSubagent((k) => process.env[k]),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const CheckVersion: AsyncHookContract<SessionStartInput, SilentOutput, CheckVersionDeps> = {

--- a/hooks/SessionFraming/GitignoreRecommender/GitignoreRecommender.contract.ts
+++ b/hooks/SessionFraming/GitignoreRecommender/GitignoreRecommender.contract.ts
@@ -14,6 +14,7 @@ import { fileReadFailed } from "@hooks/core/error";
 import { ok, type Result, tryCatch } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import { continueOk } from "@hooks/core/types/hook-outputs";
+import { defaultStderr } from "@hooks/lib/paths";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -33,7 +34,7 @@ const defaultDeps: GitignoreRecommenderDeps = {
   readFile,
   cwd: () => process.cwd(),
   paiRoot: join(process.env.HOME ?? "/", ".claude"),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 // ─── Pure Logic ───────────────────────────────────────────────────────────────

--- a/hooks/SessionFraming/LoadContext/LoadContext.contract.ts
+++ b/hooks/SessionFraming/LoadContext/LoadContext.contract.ts
@@ -14,7 +14,7 @@ import type { PaiError } from "@hooks/core/error";
 import { unknownError } from "@hooks/core/error";
 import { ok, type Result, tryCatch } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import { isSubagent } from "@hooks/lib/environment";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { getDAName } from "@hooks/lib/identity";
@@ -443,7 +443,7 @@ const defaultDeps: LoadContextDeps = {
   },
   isSubagent: () => isSubagent((k) => process.env[k]),
   baseDir: getPaiDir(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const LoadContext: AsyncHookContract<

--- a/hooks/SessionFraming/StartupGreeting/StartupGreeting.contract.ts
+++ b/hooks/SessionFraming/StartupGreeting/StartupGreeting.contract.ts
@@ -12,7 +12,7 @@ import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
-import { getPaiDir } from "@hooks/lib/paths";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 import { isSubagent } from "@hooks/lib/environment";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { persistKittySession } from "@hooks/lib/tab-setter";
@@ -62,7 +62,7 @@ const defaultDeps: StartupGreetingDeps = {
   ensureDir,
   writeFile,
   paiDir: getPaiDir(),
-  stderr: (msg) => process.stderr.write(`${msg}\n`),
+  stderr: defaultStderr,
 };
 
 export const StartupGreeting: SyncHookContract<


### PR DESCRIPTION
## Summary
- Replace ~60 inline `(msg) => process.stderr.write(msg + "\n")` lambdas with canonical `defaultStderr` from `@hooks/lib/paths`
- 60 files updated across all hook groups
- Net change: 125 insertions, 90 deletions (+35 net from added imports)

## Test plan
- [x] `npx tsc --noEmit` — no new errors
- [x] `bun test` — 3340 pass, 4 pre-existing failures, 12 skip

Closes #81

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple