### PR TITLE
refactor: replace try-catch with tryCatch()/Result in KoordDaemon contracts (#76)

### DIFF
--- a/hooks/KoordDaemon/MessageQueueRelay/MessageQueueRelay.contract.ts
+++ b/hooks/KoordDaemon/MessageQueueRelay/MessageQueueRelay.contract.ts
@@ -18,7 +18,7 @@
 
 import type { SyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
-import { ok, type Result } from "@hooks/core/result";
+import { ok, tryCatch, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import type { ContinueOutput } from "@hooks/core/types/hook-outputs";
 import { defaultStderr } from "@hooks/lib/paths";
@@ -52,15 +52,13 @@ function extractSessionFromCommand(command: string): string | null {
 
 /** Parse message JSON from watcher stdout, with fallback to raw text. */
 function parseWatcherOutput(raw: string): { from?: string; body: string; [key: string]: unknown } {
-  try {
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    return {
-      ...parsed,
-      body: typeof parsed.body === "string" ? parsed.body : raw,
-    };
-  } catch {
-    return { body: raw.trim() };
-  }
+  const result = tryCatch(() => JSON.parse(raw) as Record<string, unknown>, () => null);
+  if (!result.ok) return { body: raw.trim() };
+  const parsed = result.value;
+  return {
+    ...parsed,
+    body: typeof parsed.body === "string" ? parsed.body : raw,
+  };
 }
 
 // ─── Contract ────────────────────────────────────────────────────────────────

--- a/hooks/KoordDaemon/MessageQueueServer/MessageQueueServer.contract.ts
+++ b/hooks/KoordDaemon/MessageQueueServer/MessageQueueServer.contract.ts
@@ -19,7 +19,7 @@
 
 import type { AsyncHookContract } from "@hooks/core/contract";
 import type { PaiError } from "@hooks/core/error";
-import { ok, type Result } from "@hooks/core/result";
+import { ok, tryCatch, type Result } from "@hooks/core/result";
 import type { SessionStartInput } from "@hooks/core/types/hook-inputs";
 import type { ContextOutput, SilentOutput } from "@hooks/core/types/hook-outputs";
 import { defaultStderr } from "@hooks/lib/paths";
@@ -46,24 +46,23 @@ const defaultDeps: MessageQueueServerDeps = {
   getEnv: (name) => process.env[name],
   getKoordConfig: () => readKoordConfig(defaultReadFileOrNull),
   spawnDetached: (cmd, args) => {
-    try {
-      const child = Bun.spawn([cmd, ...args], {
-        stdout: "ignore",
-        stderr: "pipe",
-        stdin: "ignore",
-      });
-      child.unref();
-      return { ok: true };
-    } catch {
-      return { ok: false };
-    }
+    const result = tryCatch(
+      () => {
+        const child = Bun.spawn([cmd, ...args], {
+          stdout: "ignore",
+          stderr: "pipe",
+          stdin: "ignore",
+        });
+        child.unref();
+        return true;
+      },
+      () => null,
+    );
+    return { ok: result.ok };
   },
   fileExists: (path) => {
-    try {
-      return Bun.file(path).size > 0;
-    } catch {
-      return false;
-    }
+    const result = tryCatch(() => Bun.file(path).size > 0, () => null);
+    return result.ok ? result.value : false;
   },
   stderr: defaultStderr,
   getScriptPath: () => {


### PR DESCRIPTION
## Summary
- Replaces 2 try-catch blocks in `MessageQueueServer.contract.ts` defaultDeps (`spawnDetached`, `fileExists`) with `tryCatch()` from `@hooks/core/result`
- Replaces 1 try-catch block in `MessageQueueRelay.contract.ts` (`parseWatcherOutput` JSON.parse) with `tryCatch()`
- Aligns KoordDaemon contracts with the codebase-wide Result pipeline convention

## Test plan
- [x] `bun test` — 118 pass, 0 fail in KoordDaemon suite
- [x] `npx tsc --noEmit` — no new type errors

Closes #76

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple