### PR TITLE
chore: remove kitty terminal references (#56)

### DIFF
--- a/docs/groups/QuestionAnswered/QuestionAnswered.html
+++ b/docs/groups/QuestionAnswered/QuestionAnswered.html
@@ -1837,7 +1837,7 @@ This hook establishes the detection point. The heavier logic — extracting ques
         <div class="card-icon">&#x1F4CB;</div>
         <h3>Overview</h3>
       </div>
-      <p>QuestionAnswered is a <strong>PostToolUse</strong> hook that fires after an <code>AskUserQuestion</code> tool completes. Following kitty terminal removal in #56, this hook is a no-op that returns <code>silent</code> immediately.</p>
+      <p>QuestionAnswered is a <strong>PostToolUse</strong> hook that fires after an <code>AskUserQuestion</code> tool completes. This hook is a no-op that returns <code>silent</code> immediately.</p>
     </div>
   </section>
 
@@ -1848,7 +1848,7 @@ This hook establishes the detection point. The heavier logic — extracting ques
         <div class="card-icon">&#x26A1;</div>
         <h3>Event</h3>
       </div>
-      <p><code>PostToolUse</code> — fires after an <code>AskUserQuestion</code> tool completes. Returns <code>silent</code> immediately (no-op after kitty removal).</p>
+      <p><code>PostToolUse</code> — fires after an <code>AskUserQuestion</code> tool completes. Returns <code>silent</code> immediately (no-op).</p>
     </div>
   </section>
 

--- a/docs/groups/QuestionAnswered/QuestionAnswered.html
+++ b/docs/groups/QuestionAnswered/QuestionAnswered.html
@@ -1906,7 +1906,7 @@ execute(_input, _deps): Result&lt;SyncHookJSONOutput, E&gt; {
       <h3 style="color: var(--green); margin-bottom: 12px;">Example 1: User answers a question</h3>
       
       <div class="uc-example">
-        <div>Claude asks the user a question via <code>AskUserQuestion</code>. The user responds. QuestionAnswered fires and returns silent. No tab state changes occur.</div>
+        <div>Claude asks the user a question via <code>AskUserQuestion</code>. The user responds. QuestionAnswered fires and returns silent.</div>
       </div>
       </div>
     </div>

--- a/docs/groups/StopOrchestrator/StopOrchestrator.html
+++ b/docs/groups/StopOrchestrator/StopOrchestrator.html
@@ -1887,7 +1887,7 @@ A single orchestrator claims the session-stop event, parses the transcript once,
 
         <div class="flow-step">
           <div class="step-dot">3</div>
-          <div class="step-content"><p>Determines if this is a main session (always true after kitty removal in #56)</p></div>
+          <div class="step-content"><p>Determines if this is a main session (always true; subagent filtering is handled upstream)</p></div>
         </div>
 
         <div class="flow-step">

--- a/docs/groups/StopOrchestrator/StopOrchestrator.html
+++ b/docs/groups/StopOrchestrator/StopOrchestrator.html
@@ -1815,7 +1815,7 @@ A single orchestrator claims the session-stop event, parses the transcript once,
 1. Accept the session stop event and wait a short interval for the transcript to finish writing.
 2. Parse the transcript into a structured object (messages, roles, plain text summary).
 3. Check whether the current session is a primary session or a sub-session.
-4. Build the handler list: always include state restoration, skill rebuilding, and data enrichment; include voice notification only for the primary session.
+4. Build the handler list: always include skill rebuilding and data enrichment; include voice notification only for the primary session.
 5. Run all handlers concurrently using settled-promise semantics so failures are logged but do not propagate.
 6. Return silently after all handlers complete or fail.
 
@@ -1936,7 +1936,7 @@ await Promise.allSettled(handlers);</div>
       <h3 style="color: var(--green); margin-bottom: 12px;">Example 1: Main session with voice</h3>
       
       <div class="uc-example">
-        <div>Claude completes a response in the main terminal tab. StopOrchestrator parses the transcript and runs all four handlers. VoiceNotification speaks "Refactoring complete, 3 of 5 criteria satisfied", TabState updates the tab title, RebuildSkill checks for stale skills, and AlgorithmEnrichment processes the response.</div>
+        <div>Claude completes a response in the main terminal session. StopOrchestrator parses the transcript and runs all three handlers. VoiceNotification speaks "Refactoring complete, 3 of 5 criteria satisfied", RebuildSkill checks for stale skills, and AlgorithmEnrichment processes the response.</div>
       </div>
       </div>
       <div style="margin-top: 20px;">

--- a/hooks/QuestionAnswered/QuestionAnswered/QuestionAnswered.contract.ts
+++ b/hooks/QuestionAnswered/QuestionAnswered/QuestionAnswered.contract.ts
@@ -1,8 +1,8 @@
 /**
- * QuestionAnswered Contract — No-op after kitty tab removal.
+ * QuestionAnswered Contract — No-op; previously restored terminal tab color.
  *
  * Previously restored terminal tab color after AskUserQuestion.
- * Tab manipulation removed with kitty dependency (#56).
+ * Tab manipulation removed; no longer applicable.
  */
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";

--- a/hooks/QuestionAnswered/QuestionAnswered/QuestionAnswered.contract.ts
+++ b/hooks/QuestionAnswered/QuestionAnswered/QuestionAnswered.contract.ts
@@ -1,8 +1,7 @@
 /**
- * QuestionAnswered Contract — No-op; previously restored terminal tab color.
+ * QuestionAnswered Contract — No-op after AskUserQuestion.
  *
- * Previously restored terminal tab color after AskUserQuestion.
- * Tab manipulation removed; no longer applicable.
+ * Tab manipulation was removed; this hook returns ok({}) immediately.
  */
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";

--- a/hooks/QuestionAnswered/QuestionAnswered/doc.md
+++ b/hooks/QuestionAnswered/QuestionAnswered/doc.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-QuestionAnswered is a **PostToolUse** hook that fires after an `AskUserQuestion` tool completes. Following kitty terminal removal in #56, this hook is a no-op that returns `silent` immediately.
+QuestionAnswered is a **PostToolUse** hook that fires after an `AskUserQuestion` tool completes. This hook is a no-op that returns `silent` immediately.
 
 ## Event
 
-`PostToolUse` — fires after an `AskUserQuestion` tool completes. Returns `silent` immediately (no-op after kitty removal).
+`PostToolUse` — fires after an `AskUserQuestion` tool completes. Returns `silent` immediately (no-op).
 
 ## When It Fires
 

--- a/hooks/QuestionAnswered/QuestionAnswered/doc.md
+++ b/hooks/QuestionAnswered/QuestionAnswered/doc.md
@@ -31,7 +31,7 @@ execute(_input, _deps): Result<SyncHookJSONOutput, E> {
 
 ### Example 1: User answers a question
 
-> Claude asks the user a question via `AskUserQuestion`. The user responds. QuestionAnswered fires and returns silent. No tab state changes occur.
+> Claude asks the user a question via `AskUserQuestion`. The user responds. QuestionAnswered fires and returns silent.
 
 ## Dependencies
 

--- a/hooks/StopOrchestrator/IDEA.md
+++ b/hooks/StopOrchestrator/IDEA.md
@@ -4,7 +4,7 @@
 
 ## Problem
 
-When a session ends, multiple cleanup and bookkeeping tasks need to run: voice notifications, terminal state restoration, skill rebuilding, data enrichment. If each task registers independently on the session-end event, the transcript gets parsed multiple times, ordering is unpredictable, and failures in one task can interfere with others.
+When a session ends, multiple cleanup and bookkeeping tasks need to run: voice notifications, skill rebuilding, data enrichment. If each task registers independently on the session-end event, the transcript gets parsed multiple times, ordering is unpredictable, and failures in one task can interfere with others.
 
 ## Solution
 

--- a/hooks/StopOrchestrator/StopOrchestrator/IDEA.md
+++ b/hooks/StopOrchestrator/StopOrchestrator/IDEA.md
@@ -15,7 +15,7 @@ A single orchestrator claims the session-stop event, parses the transcript once,
 1. Accept the session stop event and wait a short interval for the transcript to finish writing.
 2. Parse the transcript into a structured object (messages, roles, plain text summary).
 3. Check whether the current session is a primary session or a sub-session.
-4. Build the handler list: always include state restoration, skill rebuilding, and data enrichment; include voice notification only for the primary session.
+4. Build the handler list: always include skill rebuilding and data enrichment; include voice notification only for the primary session.
 5. Run all handlers concurrently using settled-promise semantics so failures are logged but do not propagate.
 6. Return silently after all handlers complete or fail.
 

--- a/hooks/StopOrchestrator/StopOrchestrator/StopOrchestrator.contract.ts
+++ b/hooks/StopOrchestrator/StopOrchestrator/StopOrchestrator.contract.ts
@@ -4,7 +4,7 @@
  * Reads and parses the transcript ONCE, then distributes to handlers:
  * - VoiceNotification, RebuildSkill, AlgorithmEnrichment
  *
- * Voice only fires for main terminal sessions (not subagents).
+ * Voice only fires when isMainSession returns true (subagents are filtered upstream).
  */
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";

--- a/hooks/StopOrchestrator/StopOrchestrator/doc.md
+++ b/hooks/StopOrchestrator/StopOrchestrator/doc.md
@@ -24,7 +24,7 @@ It does **not** fire when:
 
 1. Waits 150ms for the transcript file to be fully written
 2. Parses the transcript using `TranscriptParser` to extract completion text
-3. Determines if this is a main session (always true after kitty removal in #56)
+3. Determines if this is a main session (always true; subagent filtering is handled upstream)
 4. Runs handlers in parallel via `Promise.allSettled`:
    - **VoiceNotification** (main sessions only): Speaks the completion summary via TTS
    - **RebuildSkill**: Checks if skills need rebuilding

--- a/hooks/StopOrchestrator/StopOrchestrator/doc.md
+++ b/hooks/StopOrchestrator/StopOrchestrator/doc.md
@@ -46,7 +46,7 @@ await Promise.allSettled(handlers);
 
 ### Example 1: Main session with voice
 
-> Claude completes a response in the main terminal tab. StopOrchestrator parses the transcript and runs all four handlers. VoiceNotification speaks "Refactoring complete, 3 of 5 criteria satisfied", TabState updates the tab title, RebuildSkill checks for stale skills, and AlgorithmEnrichment processes the response.
+> Claude completes a response in the main terminal session. StopOrchestrator parses the transcript and runs all three handlers. VoiceNotification speaks "Refactoring complete, 3 of 5 criteria satisfied", RebuildSkill checks for stale skills, and AlgorithmEnrichment processes the response.
 
 ### Example 2: Subagent session (no voice)
 

--- a/lib/output-validators.ts
+++ b/lib/output-validators.ts
@@ -140,7 +140,6 @@ function isValidTitleBase(text: string): { valid: boolean; firstWord: string } {
 
 /**
  * Working-phase title: MUST start with gerund (-ing verb).
- * Used by UpdateTabTitle for 🧠/⚙️ titles.
  */
 export function isValidWorkingTitle(text: string): boolean {
   const { valid, firstWord } = isValidTitleBase(text);
@@ -154,7 +153,6 @@ export const isValidTabSummary = isValidWorkingTitle;
 /**
  * Completion-phase title: must NOT start with gerund.
  * Past tense or other non-gerund verb forms.
- * Used by TabState for ✓ titles.
  */
 export function isValidCompletionTitle(text: string): boolean {
   const { valid, firstWord } = isValidTitleBase(text);


### PR DESCRIPTION
## Summary

- Removes all references to kitty terminal from JSDoc comments, doc.md files, and regenerated HTML docs
- Closes #56

## Changes

- `QuestionAnswered.contract.ts`: Updated JSDoc lines 2 and 5 to remove kitty-specific language
- `QuestionAnswered/doc.md`: Removed "Following kitty terminal removal in #56" from Overview; removed "(no-op after kitty removal)" from Event section
- `StopOrchestrator/doc.md`: Replaced "always true after kitty removal in #56" with "always true; subagent filtering is handled upstream"
- Regenerated HTML docs for both hooks

## Test plan

- [ ] `grep -r "kitty" hooks/` → no output
- [ ] `grep -r "kitty" docs/groups/` → no output
- [ ] `bunx tsc --noEmit` → exit 0
- [ ] `bun test hooks/QuestionAnswered hooks/StopOrchestrator` → 7 pass, 0 fail

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple