### PR TITLE
fix: implement --fix flag for verify command (#55)

### DIFF
--- a/cli/commands/verify.test.ts
+++ b/cli/commands/verify.test.ts
@@ -116,9 +116,9 @@ describe("verify source-mode", () => {
     }
   });
 
-  it("--fix mode reports fixed hooks", () => {
+  it("--fix mode rewrites stale fields and reports fixed hooks", () => {
     const repo = makeCleanSourceRepo();
-    // Remove a field that --fix can derive (e.g., empty deps so it re-derives)
+    // Inject a stale field that --fix should strip
     const manifest = JSON.parse(repo["/source/hooks/TestGroup/TestHook/hook.json"]);
     manifest.deps = ["nonexistent-dep"];
     repo["/source/hooks/TestGroup/TestHook/hook.json"] = JSON.stringify(manifest);
@@ -127,8 +127,16 @@ describe("verify source-mode", () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      // Either it fixed something or found it valid
-      expect(typeof result.value).toBe("string");
+      expect(result.value).toContain("Fixed");
+    }
+
+    // Read manifest back and assert stale field was removed
+    const rewritten = deps.readFile("/source/hooks/TestGroup/TestHook/hook.json");
+    expect(rewritten.ok).toBe(true);
+    if (rewritten.ok) {
+      const parsed = JSON.parse(rewritten.value);
+      expect(parsed.deps).toBeUndefined();
+      expect(parsed.name).toBe("TestHook");
     }
   });
 });
@@ -138,7 +146,8 @@ describe("verify source-mode", () => {
 describe("verify installed-mode", () => {
   it("clean install passes", () => {
     const deps = new InMemoryDeps(makeInstalledProject(), "/source");
-    install(installArgs(["TestHook"]), deps, "/source");
+    const installResult = install(installArgs(["TestHook"]), deps, "/source");
+    expect(installResult.ok).toBe(true);
 
     const result = verify(installedVerifyArgs({ in: "/project" }), deps);
 
@@ -150,7 +159,8 @@ describe("verify installed-mode", () => {
 
   it("modified file reported", () => {
     const deps = new InMemoryDeps(makeInstalledProject(), "/source");
-    install(installArgs(["TestHook"]), deps, "/source");
+    const installResult = install(installArgs(["TestHook"]), deps, "/source");
+    expect(installResult.ok).toBe(true);
 
     // Modify an installed file
     deps.addFile(
@@ -168,7 +178,8 @@ describe("verify installed-mode", () => {
 
   it("missing file reported", () => {
     const deps = new InMemoryDeps(makeInstalledProject(), "/source");
-    install(installArgs(["TestHook"]), deps, "/source");
+    const installResult = install(installArgs(["TestHook"]), deps, "/source");
+    expect(installResult.ok).toBe(true);
 
     // Delete an installed file
     deps.deleteFile("/project/.claude/hooks/pai-hooks/TestGroup/TestHook/TestHook.hook.ts");
@@ -213,7 +224,8 @@ describe("verify installed-mode", () => {
 
   it("missing settings entry reported", () => {
     const deps = new InMemoryDeps(makeInstalledProject(), "/source");
-    install(installArgs(["TestHook"]), deps, "/source");
+    const installResult = install(installArgs(["TestHook"]), deps, "/source");
+    expect(installResult.ok).toBe(true);
 
     // Clear settings to simulate missing entry
     deps.addFile("/project/.claude/settings.json", "{}");

--- a/cli/commands/verify.test.ts
+++ b/cli/commands/verify.test.ts
@@ -12,8 +12,32 @@ import { describe, expect, it } from "bun:test";
 import { install } from "@hooks/cli/commands/install";
 import { verify } from "@hooks/cli/commands/verify";
 import type { ParsedArgs } from "@hooks/cli/core/args";
-import { PaihErrorCode } from "@hooks/cli/core/error";
+import { PaihError, PaihErrorCode, writeFailed } from "@hooks/cli/core/error";
+import type { Result } from "@hooks/cli/core/result";
+import { err } from "@hooks/cli/core/result";
 import { InMemoryDeps } from "@hooks/cli/types/deps";
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * InMemoryDeps subclass that injects write failures for specific paths.
+ * Used to test E1: writeFile return value is checked.
+ */
+class FailingWriteDeps extends InMemoryDeps {
+  private failPaths: Set<string>;
+
+  constructor(fileTree: Record<string, string>, cwd = "/test", failPaths: string[] = []) {
+    super(fileTree, cwd);
+    this.failPaths = new Set(failPaths);
+  }
+
+  override writeFile(path: string, content: string): Result<void, PaihError> {
+    if (this.failPaths.has(path)) {
+      return err(writeFailed(path));
+    }
+    return super.writeFile(path, content);
+  }
+}
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
 
@@ -113,6 +137,93 @@ describe("verify source-mode", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value).toContain("MANIFEST_PARSE_ERROR");
+    }
+  });
+
+  // E3: non-object JSON (null, array) must not crash
+  it("reports parse error for non-object JSON (null)", () => {
+    const repo = makeCleanSourceRepo();
+    repo["/source/hooks/TestGroup/TestHook/hook.json"] = "null";
+    const deps = new InMemoryDeps(repo, "/source");
+    const result = verify(sourceVerifyArgs(), deps, "/source");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toContain("MANIFEST_PARSE_ERROR");
+    }
+  });
+
+  it("reports parse error for non-object JSON (array)", () => {
+    const repo = makeCleanSourceRepo();
+    repo["/source/hooks/TestGroup/TestHook/hook.json"] = '["not","an","object"]';
+    const deps = new InMemoryDeps(repo, "/source");
+    const result = verify(sourceVerifyArgs(), deps, "/source");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toContain("MANIFEST_PARSE_ERROR");
+    }
+  });
+
+  // E5: manifest with only stale keys must not be rewritten to {}
+  it("--fix with only stale keys reports EMPTY_MANIFEST and does not rewrite file", () => {
+    const repo = makeCleanSourceRepo();
+    repo["/source/hooks/TestGroup/TestHook/hook.json"] = JSON.stringify({ staleKey: "value" });
+    const deps = new InMemoryDeps(repo, "/source");
+    const result = verify(sourceVerifyArgs({ fix: true }), deps, "/source");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toContain("EMPTY_MANIFEST");
+      expect(result.value).not.toContain("Fixed");
+    }
+
+    // File must remain unchanged
+    const rewritten = deps.readFile("/source/hooks/TestGroup/TestHook/hook.json");
+    expect(rewritten.ok).toBe(true);
+    if (rewritten.ok) {
+      expect(JSON.parse(rewritten.value)).toEqual({ staleKey: "value" });
+    }
+  });
+
+  // E1: writeFile failure must not report fixed:true
+  it("--fix reports WRITE_FAILED and does not count as fixed when writeFile fails", () => {
+    const repo = makeCleanSourceRepo();
+    const manifest = JSON.parse(repo["/source/hooks/TestGroup/TestHook/hook.json"]);
+    manifest.staleKey = "value";
+    repo["/source/hooks/TestGroup/TestHook/hook.json"] = JSON.stringify(manifest);
+
+    const deps = new FailingWriteDeps(repo, "/source", [
+      "/source/hooks/TestGroup/TestHook/hook.json",
+    ]);
+    const result = verify(sourceVerifyArgs({ fix: true }), deps, "/source");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toContain("WRITE_FAILED");
+      expect(result.value).not.toContain("Fixed");
+    }
+  });
+
+  // E2: stale keys + missing contract must report both diagnostics
+  it("--fix reports STALE_FIELDS and CONTRACT_MISSING for a hook with both issues", () => {
+    const repo = makeCleanSourceRepo();
+    // Add stale key
+    const manifest = JSON.parse(repo["/source/hooks/TestGroup/TestHook/hook.json"]);
+    manifest.staleKey = "value";
+    repo["/source/hooks/TestGroup/TestHook/hook.json"] = JSON.stringify(manifest);
+    // Remove contract file
+    delete (repo as Record<string, string>)[
+      "/source/hooks/TestGroup/TestHook/TestHook.contract.ts"
+    ];
+
+    const deps = new InMemoryDeps(repo, "/source");
+    const result = verify(sourceVerifyArgs({ fix: true }), deps, "/source");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toContain("STALE_FIELDS");
+      expect(result.value).toContain("CONTRACT_MISSING");
     }
   });
 

--- a/cli/commands/verify.ts
+++ b/cli/commands/verify.ts
@@ -4,7 +4,7 @@
  * Source mode (default): Run in source repo, validate manifests match imports.
  *   - Globs all hook.json under hooks/
  *   - Compares declared deps vs actual imports (reuses validator logic from cli/core/validator.ts)
- *   - --fix accepted but is a no-op (auto-rewrite not yet implemented)
+ *   - --fix rewrites stale hook.json fields when stale keys are detected
  *
  * Installed mode (--installed): Run in target project, check files match lockfile.
  *   - Reads lockfile, checks all files exist + match fileHashes (cli/core/lockfile.ts)
@@ -72,8 +72,8 @@ export function verify(
 /**
  * Source-mode verify: validate hook.json manifests match actual imports.
  *
- * Note: --fix is accepted but is a no-op. Auto-rewrite of hook.json is not yet
- * implemented. The flag only suppresses the diagnostic hint below.
+ * When --fix is passed, stale keys in hook.json that are not part of the
+ * HookManifest schema are removed and the file is rewritten.
  */
 function verifySource(
   _args: ParsedArgs,
@@ -89,6 +89,7 @@ function verifySource(
   }
 
   const diagnostics: VerifyDiagnostic[] = [];
+  let fixCount = 0;
 
   // Scan group directories
   const groupDirs = deps.readDir(hooksDir);
@@ -111,10 +112,13 @@ function verifySource(
       const manifestPath = `${hookDir}/hook.json`;
       if (!deps.fileExists(manifestPath)) continue;
 
-      const result = validateHookManifest(hookName, hookDir, manifestPath, groupDir, deps);
+      const result = validateHookManifest(hookName, hookDir, manifestPath, groupDir, deps, fix);
 
       if (result.diagnostics.length > 0) {
         diagnostics.push(...result.diagnostics);
+      }
+      if (result.fixed) {
+        fixCount++;
       }
     }
   }
@@ -128,22 +132,33 @@ function verifySource(
   for (const d of diagnostics) {
     lines.push(`  [${d.code}] ${d.hookName}: ${d.message}`);
   }
-  if (!fix) {
-    lines.push("Note: --fix is accepted but not yet implemented for source mode.");
+  if (fix && fixCount > 0) {
+    lines.push(`Fixed ${fixCount} hook${fixCount === 1 ? "" : "s"}.`);
   }
   return ok(lines.join("\n"));
 }
 
 // ─── Manifest Validation ────────────────────────────────────────────────────
 
+/** Valid keys in a HookManifest (cli/types/manifest.ts). */
+const MANIFEST_VALID_KEYS = [
+  "name",
+  "group",
+  "event",
+  "description",
+  "schemaVersion",
+  "tags",
+  "presets",
+] as const;
+
 interface ManifestValidationResult {
   diagnostics: VerifyDiagnostic[];
+  fixed: boolean;
 }
 
 /**
  * Validate a single hook manifest is well-formed.
- * Dependencies are auto-discovered from imports at install time,
- * so no deps validation is needed here.
+ * When fix=true, stale keys are stripped and the manifest is rewritten.
  */
 function validateHookManifest(
   hookName: string,
@@ -151,12 +166,13 @@ function validateHookManifest(
   manifestPath: string,
   _groupDir: string,
   deps: CliDeps,
+  fix: boolean,
 ): ManifestValidationResult {
   const diagnostics: VerifyDiagnostic[] = [];
 
   // Read manifest
   const manifestContent = deps.readFile(manifestPath);
-  if (!manifestContent.ok) return { diagnostics };
+  if (!manifestContent.ok) return { diagnostics, fixed: false };
 
   const parsed = tryCatch(
     () => JSON.parse(manifestContent.value) as Record<string, unknown>,
@@ -174,7 +190,32 @@ function validateHookManifest(
       code: "MANIFEST_PARSE_ERROR",
       message: "Failed to parse hook.json",
     });
-    return { diagnostics };
+    return { diagnostics, fixed: false };
+  }
+
+  // Detect stale keys not in the HookManifest schema
+  const staleKeys = Object.keys(parsed.value).filter(
+    (k) => !(MANIFEST_VALID_KEYS as readonly string[]).includes(k),
+  );
+
+  if (staleKeys.length > 0) {
+    diagnostics.push({
+      hookName,
+      code: "STALE_FIELDS",
+      message: `Stale keys in hook.json: ${staleKeys.join(", ")}`,
+    });
+
+    if (fix) {
+      // Build cleaned manifest preserving valid-key order
+      const cleaned: Record<string, unknown> = {};
+      for (const key of MANIFEST_VALID_KEYS) {
+        if (key in parsed.value) {
+          cleaned[key] = parsed.value[key];
+        }
+      }
+      deps.writeFile(manifestPath, `${JSON.stringify(cleaned, null, 2)}\n`);
+      return { diagnostics, fixed: true };
+    }
   }
 
   // Verify contract file exists
@@ -187,7 +228,7 @@ function validateHookManifest(
     });
   }
 
-  return { diagnostics };
+  return { diagnostics, fixed: false };
 }
 
 // ─── Installed Mode ─────────────────────────────────────────────────────────

--- a/cli/commands/verify.ts
+++ b/cli/commands/verify.ts
@@ -193,10 +193,26 @@ function validateHookManifest(
     return { diagnostics, fixed: false };
   }
 
+  // E3: Guard against non-object JSON values (null, array, number, etc.)
+  if (
+    parsed.value === null ||
+    typeof parsed.value !== "object" ||
+    Array.isArray(parsed.value)
+  ) {
+    diagnostics.push({
+      hookName,
+      code: "MANIFEST_PARSE_ERROR",
+      message: "hook.json is not a JSON object",
+    });
+    return { diagnostics, fixed: false };
+  }
+
   // Detect stale keys not in the HookManifest schema
   const staleKeys = Object.keys(parsed.value).filter(
     (k) => !(MANIFEST_VALID_KEYS as readonly string[]).includes(k),
   );
+
+  let fixed = false;
 
   if (staleKeys.length > 0) {
     diagnostics.push({
@@ -213,8 +229,31 @@ function validateHookManifest(
           cleaned[key] = parsed.value[key];
         }
       }
-      deps.writeFile(manifestPath, `${JSON.stringify(cleaned, null, 2)}\n`);
-      return { diagnostics, fixed: true };
+
+      // E5: Refuse to write if no valid keys would remain
+      if (Object.keys(cleaned).length === 0) {
+        diagnostics.push({
+          hookName,
+          code: "EMPTY_MANIFEST",
+          message: "Cannot fix: no valid keys would remain after removing stale fields",
+        });
+      } else {
+        // E1: Check writeFile result — do not report fixed:true on failure
+        const writeResult = deps.writeFile(
+          manifestPath,
+          `${JSON.stringify(cleaned, null, 2)}\n`,
+        );
+        if (!writeResult.ok) {
+          diagnostics.push({
+            hookName,
+            code: "WRITE_FAILED",
+            message: `Failed to rewrite hook.json: ${writeResult.error.message}`,
+          });
+        } else {
+          fixed = true;
+        }
+      }
+      // E2: Do NOT return early — fall through to CONTRACT_MISSING check below
     }
   }
 
@@ -228,7 +267,7 @@ function validateHookManifest(
     });
   }
 
-  return { diagnostics, fixed: false };
+  return { diagnostics, fixed };
 }
 
 // ─── Installed Mode ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `--fix` in source mode now detects stale keys in `hook.json` (keys not in the `HookManifest` schema) and rewrites the file with only the valid fields
- Output says "Fixed N hook(s)" when fixes are applied; the old no-op hint line is removed
- Test for `--fix` now reads the manifest back and asserts the stale field was removed and the file name is preserved

## Test plan

- [ ] `bun test cli/commands/verify.test.ts` → 11 pass, 0 fail
- [ ] `npx tsc --noEmit` (or `node_modules/.bin/tsc --noEmit`) → exits 0
- [ ] `--fix mode rewrites stale fields` test reads manifest back, asserts `deps` key is gone and `name` is preserved
- [ ] All 4 installed-mode tests assert `installResult.ok` before calling verify

Closes #55

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple