### PR TITLE
chore: replace legacy output type names in JSDoc (#131)

### DIFF
--- a/hooks/CodeQualityPipeline/SessionQualityReport/SessionQualityReport.contract.ts
+++ b/hooks/CodeQualityPipeline/SessionQualityReport/SessionQualityReport.contract.ts
@@ -4,7 +4,7 @@
  * Reads stored baselines and final scores, generates a quality summary,
  * and writes it to MEMORY/LEARNING/QUALITY/{year}-{month}/.
  *
- * Output: SilentOutput (report written to disk, no stdout needed).
+ * Output: silent no-op (`{}`) (report written to disk, no stdout needed).
  */
 
 import { join } from "node:path";

--- a/hooks/DuplicationDetection/shared.test.ts
+++ b/hooks/DuplicationDetection/shared.test.ts
@@ -167,7 +167,7 @@ describe("normalizeReturn", () => {
   });
   test("replaces *Output suffix with *Output", () => {
     expect(normalizeReturn("SyncHookJSONOutput")).toBe("*Output");
-    expect(normalizeReturn("SyncHookJSONOutput")).toBe("*Output");
+    expect(normalizeReturn("AsyncHookJSONOutput")).toBe("*Output");
   });
   test("leaves primitive types unchanged", () => {
     expect(normalizeReturn("string")).toBe("string");

--- a/hooks/DuplicationDetection/shared.test.ts
+++ b/hooks/DuplicationDetection/shared.test.ts
@@ -166,8 +166,8 @@ describe("normalizeReturn", () => {
     expect(normalizeReturn("SessionEndInput")).toBe("*Input");
   });
   test("replaces *Output suffix with *Output", () => {
-    expect(normalizeReturn("ContinueOutput")).toBe("*Output");
-    expect(normalizeReturn("BlockOutput")).toBe("*Output");
+    expect(normalizeReturn("SyncHookJSONOutput")).toBe("*Output");
+    expect(normalizeReturn("SyncHookJSONOutput")).toBe("*Output");
   });
   test("leaves primitive types unchanged", () => {
     expect(normalizeReturn("string")).toBe("string");

--- a/hooks/GitSafety/GitAutoSync/GitAutoSync.contract.ts
+++ b/hooks/GitSafety/GitAutoSync/GitAutoSync.contract.ts
@@ -3,7 +3,7 @@
  *
  * Pipeline: check status → debounce → add → commit → backup → pull → push.
  * Runs as last SessionEnd hook so other hooks have written their changes.
- * Always returns SilentOutput — never blocks session end.
+ * Always returns silent no-op (`{}`) — never blocks session end.
  */
 
 import { join } from "node:path";

--- a/hooks/GitSafety/WorktreeSafetyVerification/WorktreeSafetyVerification.contract.ts
+++ b/hooks/GitSafety/WorktreeSafetyVerification/WorktreeSafetyVerification.contract.ts
@@ -5,7 +5,7 @@
  * 2. Dependency install (background)
  * 3. Baseline tests (background)
  *
- * Always returns ContinueOutput — never blocks worktree creation.
+ * Always returns bare continue (`{ continue: true }`) — never blocks worktree creation.
  */
 
 import { dirname, join } from "node:path";

--- a/hooks/LastResponseCache/LastResponseCache/LastResponseCache.contract.ts
+++ b/hooks/LastResponseCache/LastResponseCache/LastResponseCache.contract.ts
@@ -5,7 +5,7 @@
  * to MEMORY/STATE/last-response.txt (truncated to 2000 chars). RatingCapture
  * (UserPromptSubmit) reads this file to get context on the previous response.
  *
- * Always returns SilentOutput — never blocks or delays the Stop event.
+ * Always returns silent no-op (`{}`) — never blocks or delays the Stop event.
  */
 
 import { join } from "node:path";

--- a/hooks/LearningFeedback/RatingCapture/RatingCapture.contract.ts
+++ b/hooks/LearningFeedback/RatingCapture/RatingCapture.contract.ts
@@ -2,10 +2,10 @@
  * RatingCapture Contract — Unified Rating & Sentiment Capture.
  *
  * Two responsibilities:
- * 1. Immediate: Output algorithm format reminder (ContextOutput)
+ * 1. Immediate: Output algorithm format reminder (hookSpecificOutput with additionalContext)
  * 2. Async: Parse explicit ratings or run implicit sentiment analysis
  *
- * The contract returns ContextOutput for the algorithm reminder.
+ * The contract returns hookSpecificOutput with additionalContext for the algorithm reminder.
  * Rating/sentiment writes happen as side effects via deps.
  */
 

--- a/hooks/WikiPipeline/WikiIngest/WikiIngest.contract.ts
+++ b/hooks/WikiPipeline/WikiIngest/WikiIngest.contract.ts
@@ -4,7 +4,7 @@
  * Runs the Filter -> Extract -> Seed pipeline automatically after each session.
  * Gates: size check (<5KB skip), wiki-only guard, dedup check.
  * Calls pipeline tools via shell (they live in MEMORY/WIKI/.pipeline/).
- * Always returns silent() — never blocks session end.
+ * Always returns silent no-op ({}) — never blocks session end.
  */
 
 import { basename, join } from "node:path";

--- a/hooks/WikiPipeline/WikiReadTracker/WikiReadTracker.test.ts
+++ b/hooks/WikiPipeline/WikiReadTracker/WikiReadTracker.test.ts
@@ -130,7 +130,7 @@ describe("WikiReadTracker.execute()", () => {
     expect(appendedContent.endsWith("\n")).toBe(true);
   });
 
-  it("returns continueOk even when appendFile fails", () => {
+  it("returns bare continue even when appendFile fails", () => {
     const deps = makeDeps({
       appendFile: () => ({
         ok: false as const,
@@ -165,7 +165,7 @@ describe("WikiReadTracker.execute()", () => {
     expect(stderrMessages[0]).toContain("WikiReadTracker");
   });
 
-  it("returns continueOk when session_id is missing", () => {
+  it("returns bare continue when session_id is missing", () => {
     const deps = makeDeps();
     const input: ToolHookInput = {
       session_id: "",


### PR DESCRIPTION
## Summary

- Replaces `ContinueOutput`, `SilentOutput`, `ContextOutput`, and `BlockOutput` legacy type name references in JSDoc comments and test strings across 6 files
- Test inputs in `shared.test.ts` updated to use `SyncHookJSONOutput` (the current SDK type name)
- JSDoc descriptions now use concrete output shape descriptions (`silent no-op (\`{}\`)`, `bare continue (\`{ continue: true }\`)`, `hookSpecificOutput with additionalContext`) instead of obsolete type aliases

## Test plan

- [ ] `grep -rn "ContinueOutput\|SilentOutput\|ContextOutput\|BlockOutput" --include="*.ts" . | grep -v node_modules | grep -v docs/plans` → 0 results
- [ ] `bun test hooks/DuplicationDetection/shared.test.ts` → 32 pass, 0 fail
- [ ] `bun x tsc --noEmit` → exits 0

Closes #131

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple