### PR TITLE
fix: normalize empty tool event output to continue:true (#127)

### DIFF
--- a/core/runner.coverage.test.ts
+++ b/core/runner.coverage.test.ts
@@ -4,7 +4,7 @@ import type { HookContract } from "@hooks/core/contract";
 import { ErrorCode, invalidInput, ResultError } from "@hooks/core/error";
 import { err, ok } from "@hooks/core/result";
 import { type RunHookOptions, runHook, runHookWith } from "@hooks/core/runner";
-import type { SessionStartInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
+import type { SessionStartInput, StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 
@@ -274,17 +274,33 @@ describe("runHook — ask output format", () => {
 // ─── runHookWith — silent and updatedInput output ────────────────────────────
 
 describe("runHookWith — output edge cases", () => {
-  it("produces no stdout for silent output", async () => {
-    const silentContract: HookContract<ToolHookInput, {}> = {
+  it("produces no stdout for silent output on Stop contracts", async () => {
+    const silentContract: HookContract<StopInput, {}> = {
       name: "TestSilentWith",
       event: "Stop",
       accepts: () => true,
       execute: () => ok({}),
       defaultDeps: {},
     };
+    const validStopInput: StopInput = { session_id: "test-sess" };
     const io = createMockIO();
-    await runHookWith(silentContract, validToolInput, io);
+    await runHookWith(silentContract, validStopInput, io);
     expect(io.stdoutLines.length).toBe(0);
+    expect(io.exitCode).toBe(0);
+  });
+
+  it("PostToolUse ok({}) normalizes to { continue: true } via runHookWith", async () => {
+    const toolEmptyContract: HookContract<ToolHookInput, {}> = {
+      name: "TestToolEmptyWith",
+      event: "PostToolUse",
+      accepts: () => true,
+      execute: () => ok({}),
+      defaultDeps: {},
+    };
+    const io = createMockIO();
+    await runHookWith(toolEmptyContract, validToolInput, io);
+    expect(io.stdoutLines.length).toBe(1);
+    expect(JSON.parse(io.stdoutLines[0])).toEqual({ continue: true });
     expect(io.exitCode).toBe(0);
   });
 

--- a/core/runner.coverage.test.ts
+++ b/core/runner.coverage.test.ts
@@ -4,7 +4,7 @@ import type { HookContract } from "@hooks/core/contract";
 import { ErrorCode, invalidInput, ResultError } from "@hooks/core/error";
 import { err, ok } from "@hooks/core/result";
 import { type RunHookOptions, runHook, runHookWith } from "@hooks/core/runner";
-import type { SessionStartInput, StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
+import type { PermissionRequestInput, SessionStartInput, StopInput, ToolHookInput } from "@hooks/core/types/hook-inputs";
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 
@@ -72,7 +72,7 @@ describe("runHookWith — pre-built input pipeline", () => {
     expect(io.exitCode).toBe(0);
   });
 
-  it("exits 0 when accepts() returns false", async () => {
+  it("exits 0 and emits { continue: true } when accepts() returns false for tool events", async () => {
     const contract: HookContract<ToolHookInput, {}> = {
       name: "TestReject",
       event: "PostToolUse",
@@ -82,7 +82,8 @@ describe("runHookWith — pre-built input pipeline", () => {
     };
     const io = createMockIO();
     await runHookWith(contract, validToolInput, io);
-    expect(io.stdoutLines.length).toBe(0);
+    expect(io.stdoutLines.length).toBe(1);
+    expect(JSON.parse(io.stdoutLines[0])).toEqual({ continue: true });
     expect(io.exitCode).toBe(0);
   });
 
@@ -325,7 +326,7 @@ describe("runHookWith — output edge cases", () => {
     expect(parsed.hookSpecificOutput.updatedInput.command).toBe("ls -la");
   });
 
-  it("skips duplicate in runHookWith", async () => {
+  it("skips duplicate in runHookWith and emits { continue: true } for tool events", async () => {
     const contract: HookContract<ToolHookInput, {}> = {
       name: "TestDedupWith",
       event: "PostToolUse",
@@ -337,7 +338,32 @@ describe("runHookWith — output edge cases", () => {
     (io as RunHookOptions).isDuplicate = () => true;
     await runHookWith(contract, validToolInput, io);
     expect(io.exitCode).toBe(0);
-    expect(io.stdoutLines.length).toBe(0);
+    expect(io.stdoutLines.length).toBe(1);
+    expect(JSON.parse(io.stdoutLines[0])).toEqual({ continue: true });
+  });
+});
+
+// ─── PermissionRequest Normalization Tests ───────────────────────────────────
+
+describe("runHookWith — PermissionRequest ok({}) normalization", () => {
+  it("PermissionRequest ok({}) normalizes to { continue: true }", async () => {
+    const permContract: HookContract<PermissionRequestInput, {}> = {
+      name: "TestPermissionRequest",
+      event: "PermissionRequest",
+      accepts: () => true,
+      execute: () => ok({}),
+      defaultDeps: {},
+    };
+    const validPermInput: PermissionRequestInput = {
+      session_id: "test-sess",
+      tool_name: "Bash",
+      tool_input: { command: "ls" },
+    };
+    const io = createMockIO();
+    await runHookWith(permContract, validPermInput, io);
+    expect(io.stdoutLines.length).toBe(1);
+    expect(JSON.parse(io.stdoutLines[0])).toEqual({ continue: true });
+    expect(io.exitCode).toBe(0);
   });
 });
 

--- a/core/runner.test.ts
+++ b/core/runner.test.ts
@@ -3,7 +3,7 @@ import type { HookContract } from "./contract";
 import { invalidInput } from "./error";
 import { err, ok } from "./result";
 import { type RunHookOptions, runHook } from "./runner";
-import type { ToolHookInput } from "./types/hook-inputs";
+import type { StopInput, ToolHookInput } from "./types/hook-inputs";
 
 // ─── Test Helpers ────────────────────────────────────────────────────────────
 
@@ -133,8 +133,8 @@ const asyncContract: HookContract<ToolHookInput, {}> = {
   defaultDeps: {},
 };
 
-// Empty output contract (previously "silent")
-const emptyOutput: HookContract<ToolHookInput, {}> = {
+// Empty output contract (previously "silent") — Stop events carry no tool_name
+const emptyOutput: HookContract<StopInput, {}> = {
   name: "TestEmpty",
   event: "Stop",
   accepts: () => true,
@@ -146,6 +146,10 @@ const validToolInput = JSON.stringify({
   session_id: "test-sess",
   tool_name: "TaskUpdate",
   tool_input: { taskId: "C1", status: "in_progress" },
+});
+
+const validStopInput = JSON.stringify({
+  session_id: "test-sess",
 });
 
 // ─── Pipeline Tests ──────────────────────────────────────────────────────────
@@ -245,10 +249,25 @@ describe("runHook — output types", () => {
     expect(output.hookSpecificOutput.additionalContext).toBe("async done");
   });
 
-  it("empty output produces no stdout", async () => {
+  it("empty output produces no stdout for Stop contracts", async () => {
     const io = createMockIO();
-    await runHook(emptyOutput, { ...io, stdinOverride: validToolInput });
+    await runHook(emptyOutput, { ...io, stdinOverride: validStopInput });
     expect(io.stdoutLines.length).toBe(0);
+    expect(io.exitCode).toBe(0);
+  });
+
+  it("PostToolUse ok({}) normalizes to { continue: true }", async () => {
+    const toolEmptyContract: HookContract<ToolHookInput, {}> = {
+      name: "TestToolEmpty",
+      event: "PostToolUse",
+      accepts: () => true,
+      execute: () => ok({}),
+      defaultDeps: {},
+    };
+    const io = createMockIO();
+    await runHook(toolEmptyContract, { ...io, stdinOverride: validToolInput });
+    expect(io.stdoutLines.length).toBe(1);
+    expect(JSON.parse(io.stdoutLines[0])).toEqual({ continue: true });
     expect(io.exitCode).toBe(0);
   });
 });

--- a/core/runner.ts
+++ b/core/runner.ts
@@ -154,10 +154,15 @@ async function executePipeline<I extends HookInput, D>(
   // Direct serialization — contracts return SyncHookJSONOutput, no mapping needed
   // Invariant: "{}" is the canonical silent/no-op shape and never carries semantic
   // meaning. Suppressing it avoids writing empty output to Claude Code's stdin.
+  // Exception: tool events (PostToolUse, PreToolUse, PermissionRequest) require
+  // { continue: true } even when the contract returns the silent no-op shape,
+  // because Claude Code expects an explicit continue signal for tool events.
   const json = JSON.stringify(result.value);
   const hasOutput = json !== "{}";
   if (hasOutput) {
     io.write(json);
+  } else if ("tool_name" in input) {
+    io.write(JSON.stringify({ continue: true }));
   }
   emitLog("ok", undefined, hasOutput ? "output" : "silent");
   io.exit(0);

--- a/core/runner.ts
+++ b/core/runner.ts
@@ -164,7 +164,7 @@ async function executePipeline<I extends HookInput, D>(
   } else if ("tool_name" in input) {
     io.write(JSON.stringify({ continue: true }));
   }
-  emitLog("ok", undefined, hasOutput ? "output" : "silent");
+  emitLog("ok", undefined, hasOutput || "tool_name" in input ? "output" : "silent");
   io.exit(0);
 }
 
@@ -196,7 +196,12 @@ export async function runHookWith<I extends HookInput, D>(
   options: Omit<RunHookOptions, "stdinOverride" | "stdinTimeout"> = {},
 ): Promise<void> {
   const io = createPipelineIO(options);
-  const safeExit = () => io.exit(0);
+  const safeExit = () => {
+    if ("tool_name" in input) {
+      io.write(JSON.stringify({ continue: true }));
+    }
+    io.exit(0);
+  };
 
   await executePipeline(contract, input, io, safeExit).catch((e) => {
     io.writeErr(`[${contract.name}] uncaught: ${e instanceof Error ? e.message : e}`);


### PR DESCRIPTION
## Summary

- Tool event contracts (PostToolUse, PreToolUse, PermissionRequest) returning `ok({})` previously wrote nothing to stdout; Claude Code expects `{ continue: true }` for tool events
- Added `else if ("tool_name" in input)` branch in `executePipeline` (`core/runner.ts`) to emit `{ continue: true }` when the output is the silent `{}` shape and the input is a tool event
- Fixed existing Stop-event test fixtures to use a Stop-shaped input (no `tool_name`) so the "no stdout" invariant holds only for non-tool events; added two new tests verifying the normalization path

## Test plan

- [ ] `bun test core/runner.test.ts core/runner.coverage.test.ts` — 34 tests, 0 failures
- [ ] `bunx tsc --noEmit` — clean, no type errors
- [ ] PostToolUse `ok({})` → stdout contains `{ continue: true }` (new test in both files)
- [ ] Stop `ok({})` → stdout empty, no regression (existing test updated to use Stop-shaped input)

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple