### PR TITLE
feat: add semantic validation for contradictory output fields (#128)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@types/bun": "^1.3.10",
         "husky": "^9.0.0",
         "type-fest": "^5.5.0",
+        "typescript": "^6.0.2",
       },
     },
   },
@@ -281,6 +282,8 @@
     "type-fest": ["type-fest@5.5.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/core/runner.coverage.test.ts
+++ b/core/runner.coverage.test.ts
@@ -365,6 +365,70 @@ describe("runHook — output validation failure (fail-open path)", () => {
   });
 });
 
+// ─── Semantic Validation Warning Tests ──────────────────────────────────────
+
+describe("runHook — semantic validation warning (warn-and-pass-through)", () => {
+  it("emits stderr warning for continue:true + decision:block contradiction", async () => {
+    const contradictoryContract: HookContract<ToolHookInput, {}> = {
+      name: "TestSemanticWarn",
+      event: "PostToolUse",
+      accepts: () => true,
+      execute: () =>
+        ok({
+          continue: true,
+          decision: "block" as const,
+          reason: "some reason",
+        }),
+      defaultDeps: {},
+    };
+    const io = createMockIO();
+    await runHook(contradictoryContract, { ...io, stdinOverride: validToolInputJson });
+    expect(io.stderrLines.some((l) => l.includes("semantic validation warning"))).toBe(true);
+    expect(io.stderrLines.some((l) => l.includes("mutually exclusive"))).toBe(true);
+  });
+
+  it("passes the original output through unchanged despite contradiction", async () => {
+    const contradictoryContract: HookContract<ToolHookInput, {}> = {
+      name: "TestSemanticPassThrough",
+      event: "PostToolUse",
+      accepts: () => true,
+      execute: () =>
+        ok({
+          continue: true,
+          decision: "block" as const,
+          reason: "pass through me",
+        }),
+      defaultDeps: {},
+    };
+    const io = createMockIO();
+    await runHook(contradictoryContract, { ...io, stdinOverride: validToolInputJson });
+    expect(io.stdoutLines.length).toBe(1);
+    const output = JSON.parse(io.stdoutLines[0]);
+    expect(output.continue).toBe(true);
+    expect(output.decision).toBe("block");
+    expect(output.reason).toBe("pass through me");
+    expect(io.exitCode).toBe(0);
+  });
+
+  it("does not emit semantic warning for a valid output", async () => {
+    const validContract: HookContract<ToolHookInput, {}> = {
+      name: "TestSemanticClean",
+      event: "PostToolUse",
+      accepts: () => true,
+      execute: () =>
+        ok({
+          decision: "block" as const,
+          reason: "clean block",
+        }),
+      defaultDeps: {},
+    };
+    const io = createMockIO();
+    await runHook(validContract, { ...io, stdinOverride: validToolInputJson });
+    expect(io.stderrLines.some((l) => l.includes("semantic validation warning"))).toBe(false);
+    expect(io.exitCode).toBe(0);
+  });
+});
+
 // ─── runHook — additional branches ──────────────────────────────────────────
 
 describe("runHook — stdin and dedup branches", () => {

--- a/core/runner.ts
+++ b/core/runner.ts
@@ -18,7 +18,10 @@ import {
   getEventType as schemaGetEventType,
 } from "@hooks/core/types/hook-input-schema";
 import type { HookEventType, HookInput, HookInputBase } from "@hooks/core/types/hook-inputs";
-import { validateHookOutput } from "@hooks/core/types/hook-output-schema";
+import {
+  validateHookOutput,
+  validateOutputSemantics,
+} from "@hooks/core/types/hook-output-schema";
 
 // ─── Event Resolution ──────────────────────────────────────────────────────
 
@@ -149,6 +152,12 @@ async function executePipeline<I extends HookInput, D>(
     io.write(JSON.stringify({ continue: true }));
     io.exit(0);
     return;
+  }
+
+  // Semantic validation — warn on contradictions but pass output through unchanged
+  const semanticWarning = validateOutputSemantics(validated.right);
+  if (semanticWarning !== null) {
+    io.writeErr(`[${contract.name}] semantic validation warning: ${semanticWarning}`);
   }
 
   // Direct serialization — contracts return SyncHookJSONOutput, no mapping needed

--- a/core/types/hook-output-schema.test.ts
+++ b/core/types/hook-output-schema.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { validateHookOutput } from "./hook-output-schema";
+import { validateHookOutput, validateOutputSemantics } from "./hook-output-schema";
 
 describe("hook-output-schema", () => {
   it("validates a bare continue output (R1)", () => {
@@ -164,5 +164,89 @@ describe("hook-output-schema", () => {
       },
     });
     expect(result._tag).toBe("Left");
+  });
+});
+
+// ─── validateOutputSemantics ─────────────────────────────────────────────────
+
+describe("validateOutputSemantics", () => {
+  // ── Contradiction 1: continue:true + decision:block ──────────────────────
+  it("flags continue:true with decision:block", () => {
+    expect(
+      validateOutputSemantics({ continue: true, decision: "block", reason: "bad" }),
+    ).toBe("continue:true and decision:block are mutually exclusive");
+  });
+
+  it("returns null for continue:true with decision:approve", () => {
+    expect(validateOutputSemantics({ continue: true, decision: "approve" })).toBeNull();
+  });
+
+  // ── Contradiction 2: decision:block without reason ───────────────────────
+  it("flags decision:block without reason", () => {
+    expect(validateOutputSemantics({ decision: "block" })).toBe(
+      "decision:block requires a reason",
+    );
+  });
+
+  it("returns null for decision:block with reason", () => {
+    expect(validateOutputSemantics({ decision: "block", reason: "dangerous" })).toBeNull();
+  });
+
+  // ── Contradiction 3: continue:true + stopReason ──────────────────────────
+  it("flags continue:true with stopReason present", () => {
+    expect(validateOutputSemantics({ continue: true, stopReason: "done" })).toBe(
+      "continue:true and stopReason are mutually exclusive",
+    );
+  });
+
+  it("returns null for continue:true without stopReason", () => {
+    expect(validateOutputSemantics({ continue: true })).toBeNull();
+  });
+
+  // ── Contradiction 4: PreToolUse permissionDecision:deny + continue:true ──
+  it("flags PreToolUse permissionDecision:deny with continue:true", () => {
+    expect(
+      validateOutputSemantics({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+        },
+      }),
+    ).toBe("PreToolUse permissionDecision:deny should not set continue:true");
+  });
+
+  it("returns null for PreToolUse permissionDecision:allow with continue:true", () => {
+    expect(
+      validateOutputSemantics({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "allow",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for PostToolUse with continue:true (no PreToolUse deny)", () => {
+    expect(
+      validateOutputSemantics({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: "PostToolUse",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  // ── Valid combinations ────────────────────────────────────────────────────
+  it("returns null for empty output", () => {
+    expect(validateOutputSemantics({})).toBeNull();
+  });
+
+  it("returns null for continue:false with decision:block and reason", () => {
+    expect(
+      validateOutputSemantics({ continue: false, decision: "block", reason: "blocked" }),
+    ).toBeNull();
   });
 });

--- a/core/types/hook-output-schema.test.ts
+++ b/core/types/hook-output-schema.test.ts
@@ -192,6 +192,12 @@ describe("validateOutputSemantics", () => {
     expect(validateOutputSemantics({ decision: "block", reason: "dangerous" })).toBeNull();
   });
 
+  it("flags decision:block with whitespace-only reason", () => {
+    expect(validateOutputSemantics({ decision: "block", reason: "   " })).toBe(
+      "decision:block requires a reason",
+    );
+  });
+
   // ── Contradiction 3: continue:true + stopReason ──────────────────────────
   it("flags continue:true with stopReason present", () => {
     expect(validateOutputSemantics({ continue: true, stopReason: "done" })).toBe(

--- a/core/types/hook-output-schema.ts
+++ b/core/types/hook-output-schema.ts
@@ -220,6 +220,44 @@ export function validateHookOutput(raw: unknown): ReturnType<typeof validateSync
   return validateSync(raw);
 }
 
+// ─── Semantic Validation ────────────────────────────────────────────────────
+
+/**
+ * Check a validated hook output for contradictory field combinations that are
+ * semantically invalid but pass schema validation.
+ *
+ * Returns the first contradiction message found, or null if no contradictions.
+ */
+export function validateOutputSemantics(output: SyncHookJSONOutputType): string | null {
+  const { continue: cont, decision, reason, stopReason, hookSpecificOutput } = output;
+
+  // 1. continue:true and decision:block are mutually exclusive
+  if (cont === true && decision === "block") {
+    return "continue:true and decision:block are mutually exclusive";
+  }
+
+  // 2. decision:block requires a reason
+  if (decision === "block" && !reason) {
+    return "decision:block requires a reason";
+  }
+
+  // 3. continue:true and stopReason are mutually exclusive
+  if (cont === true && stopReason !== undefined) {
+    return "continue:true and stopReason are mutually exclusive";
+  }
+
+  // 4. PreToolUse permissionDecision:deny should not set continue:true
+  if (
+    cont === true &&
+    hookSpecificOutput?.hookEventName === "PreToolUse" &&
+    hookSpecificOutput.permissionDecision === "deny"
+  ) {
+    return "PreToolUse permissionDecision:deny should not set continue:true";
+  }
+
+  return null;
+}
+
 // ─── SDK Drift Protection ───────────────────────────────────────────────────
 //
 // Compile-time assertion: if the SDK and Effect Schema top-level keys diverge, this fails.

--- a/core/types/hook-output-schema.ts
+++ b/core/types/hook-output-schema.ts
@@ -237,7 +237,7 @@ export function validateOutputSemantics(output: SyncHookJSONOutputType): string 
   }
 
   // 2. decision:block requires a reason
-  if (decision === "block" && !reason) {
+  if (decision === "block" && !reason?.trim()) {
     return "decision:block requires a reason";
   }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@swc/core": "^1.15.21",
     "@types/bun": "^1.3.10",
     "husky": "^9.0.0",
-    "type-fest": "^5.5.0"
+    "type-fest": "^5.5.0",
+    "typescript": "^6.0.2"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.98",


### PR DESCRIPTION
## Summary

- Adds `validateOutputSemantics(output): string | null` to `core/types/hook-output-schema.ts` — checks four contradictory field combinations that pass schema validation but are semantically invalid
- Wires semantic validation into `core/runner.ts` after schema validation succeeds: emits a stderr warning but passes the original output through unchanged
- Adds unit tests in `core/types/hook-output-schema.test.ts` and an integration test in `core/runner.coverage.test.ts`

**Four contradictions checked:**
1. `continue:true` + `decision:block` — mutually exclusive
2. `decision:block` without `reason` — block requires a reason
3. `continue:true` + `stopReason` — mutually exclusive
4. PreToolUse `permissionDecision:deny` + `continue:true` — deny should not set continue

## Test plan

- [ ] `bun test core/types/hook-output-schema.test.ts core/runner.coverage.test.ts` — 47 pass, 0 fail
- [ ] `node_modules/.bin/tsc --noEmit` — clean (no errors)
- [ ] All four contradiction messages return exactly as specified in the scoping doc
- [ ] Valid combinations return `null`
- [ ] Runner emits `semantic validation warning:` on stderr for contradictory output
- [ ] Runner passes original contradictory output through to stdout unchanged (not replaced with `{continue:true}`)
- [ ] Pre-existing test failure (`blockCountPath tuple appears`) confirmed present on base branch — not introduced by this PR

Closes #128

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple