### PR TITLE
refactor(SteeringRuleInjector): cleanup and finalization (#132)

### DIFF
--- a/docs/groups/SteeringRuleInjector/SteeringRuleInjector.html
+++ b/docs/groups/SteeringRuleInjector/SteeringRuleInjector.html
@@ -1825,14 +1825,14 @@ Store steering rules as individual markdown files with YAML frontmatter declarin
 1. Each steering rule is a markdown file with YAML frontmatter containing `name`, `events` (which hook events trigger it), and `keywords` (terms that activate it on keyword-matched events).
 2. On `SessionStart`, all rules declaring `SessionStart` with empty keywords inject automatically — always-on session-level rules.
 3. On `UserPromptSubmit`, rules declaring that event are checked against the prompt text; rules whose keywords appear in the text inject as context.
-4. On `PreToolUse` and `PostToolUse`, rules are matched against the tool name and file path; matching rules inject as `additionalContext` before or after the tool runs.
+4. On `PreToolUse` and `PostToolUse`, rules are matched against the tool name, file path, and skill; matching rules inject as `additionalContext` before or after the tool runs.
 5. On `SubagentStart`, rules with `SubagentStart` and empty keywords inject automatically, surfacing role and permission rules at the start of every subagent session.
 6. On `Stop`, rules are matched against the last assistant message; a match blocks the response with the rule body as the reason, forcing a retry.
 7. Rules already injected this session are skipped — each rule injects at most once per session via a per-session tracker file.
 
 ## Signals
 
-- **Input:** Hook event type; prompt text (UserPromptSubmit), tool name and file path (PreToolUse/PostToolUse), last assistant message (Stop); steering rule files on disk
+- **Input:** Hook event type; prompt text (UserPromptSubmit), tool name, file path, and skill (PreToolUse/PostToolUse), last assistant message (Stop); steering rule files on disk
 - **Output:** Context injection with the body of all matching rules for context events (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, SubagentStart); block decision with rule body as reason for Stop events; silent if no rules match
 </script>
   </div>
@@ -1848,7 +1848,7 @@ Store steering rules as individual markdown files with YAML frontmatter declarin
         <h3>Overview</h3>
       </div>
       <p>Injects individual steering rule files into context based on event type and keyword matching. Rules are <code>.md</code> files with YAML frontmatter declaring when they should fire. Each rule injects at most once per session, tracked via a gitignored JSON file.</p>
-      <p>Registered for <code>SessionStart</code>, <code>UserPromptSubmit</code>, <code>PreToolUse</code>, <code>PostToolUse</code>, <code>SubagentStart</code>, and <code>Stop</code>. Skips subagent sessions (except on <code>SubagentStart</code> itself).</p>
+      <p>Registered for <code>SessionStart</code>, <code>UserPromptSubmit</code>, <code>PreToolUse</code>, <code>PostToolUse</code>, <code>SubagentStart</code>, and <code>Stop</code>. Skips subagent sessions.</p>
     </div>
   </section>
 

--- a/docs/groups/SteeringRuleInjector/SteeringRuleInjector.html
+++ b/docs/groups/SteeringRuleInjector/SteeringRuleInjector.html
@@ -1822,16 +1822,18 @@ Store steering rules as individual markdown files with YAML frontmatter declarin
 
 ## How It Works
 
-1. Each steering rule is a markdown file with YAML frontmatter containing `name`, `events` (which hook events trigger it), and `keywords` (terms that activate it on prompt events).
-2. At session start, all rules declaring `SessionStart` in their events are injected as context.
-3. On each user prompt, the hook scans for rules declaring `UserPromptSubmit` and checks if any of their keywords appear in the prompt text.
-4. Matching rules have their markdown body (everything after the frontmatter) injected as context.
-5. Rules that do not match are silently skipped — zero cost when not triggered.
+1. Each steering rule is a markdown file with YAML frontmatter containing `name`, `events` (which hook events trigger it), and `keywords` (terms that activate it on keyword-matched events).
+2. On `SessionStart`, all rules declaring `SessionStart` with empty keywords inject automatically — always-on session-level rules.
+3. On `UserPromptSubmit`, rules declaring that event are checked against the prompt text; rules whose keywords appear in the text inject as context.
+4. On `PreToolUse` and `PostToolUse`, rules are matched against the tool name and file path; matching rules inject as `additionalContext` before or after the tool runs.
+5. On `SubagentStart`, rules with `SubagentStart` and empty keywords inject automatically, surfacing role and permission rules at the start of every subagent session.
+6. On `Stop`, rules are matched against the last assistant message; a match blocks the response with the rule body as the reason, forcing a retry.
+7. Rules already injected this session are skipped — each rule injects at most once per session via a per-session tracker file.
 
 ## Signals
 
-- **Input:** Hook event type, user prompt text (for UserPromptSubmit), steering rule files on disk
-- **Output:** Context injection containing the body of all matching steering rules, or silent if no rules match
+- **Input:** Hook event type; prompt text (UserPromptSubmit), tool name and file path (PreToolUse/PostToolUse), last assistant message (Stop); steering rule files on disk
+- **Output:** Context injection with the body of all matching rules for context events (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, SubagentStart); block decision with rule body as reason for Stop events; silent if no rules match
 </script>
   </div>
 
@@ -2031,7 +2033,6 @@ Rule content injected as context...</div>
 <div class="reason"><span class="ri">&#x2022;</span> <code>lib/paths</code> — <code>getPaiDir()</code> for tracker file location</div>
 <div class="reason"><span class="ri">&#x2022;</span> <code>core/adapters/fs</code> — <code>readFile</code>, <code>readJson</code>, <code>writeJson</code>, <code>fileExists</code> for rule and tracker I/O</div>
 <div class="reason"><span class="ri">&#x2022;</span> <code>core/types/hook-input-schema</code> — Effect Schema for discriminated input parsing (replaces field-sniffing)</div>
-<div class="reason"><span class="ri">&#x2022;</span> <code>Bun.Glob</code> — resolves include patterns to file paths</div>
 <div class="reason"><span class="ri">&#x2022;</span> <code>Bun.Glob</code> — resolves include patterns to file paths</div>
     </div>
   </section>

--- a/hooks/SteeringRuleInjector/SteeringRuleInjector/IDEA.md
+++ b/hooks/SteeringRuleInjector/SteeringRuleInjector/IDEA.md
@@ -15,12 +15,12 @@ Store steering rules as individual markdown files with YAML frontmatter declarin
 1. Each steering rule is a markdown file with YAML frontmatter containing `name`, `events` (which hook events trigger it), and `keywords` (terms that activate it on keyword-matched events).
 2. On `SessionStart`, all rules declaring `SessionStart` with empty keywords inject automatically — always-on session-level rules.
 3. On `UserPromptSubmit`, rules declaring that event are checked against the prompt text; rules whose keywords appear in the text inject as context.
-4. On `PreToolUse` and `PostToolUse`, rules are matched against the tool name and file path; matching rules inject as `additionalContext` before or after the tool runs.
+4. On `PreToolUse` and `PostToolUse`, rules are matched against the tool name, file path, and skill; matching rules inject as `additionalContext` before or after the tool runs.
 5. On `SubagentStart`, rules with `SubagentStart` and empty keywords inject automatically, surfacing role and permission rules at the start of every subagent session.
 6. On `Stop`, rules are matched against the last assistant message; a match blocks the response with the rule body as the reason, forcing a retry.
 7. Rules already injected this session are skipped — each rule injects at most once per session via a per-session tracker file.
 
 ## Signals
 
-- **Input:** Hook event type; prompt text (UserPromptSubmit), tool name and file path (PreToolUse/PostToolUse), last assistant message (Stop); steering rule files on disk
+- **Input:** Hook event type; prompt text (UserPromptSubmit), tool name, file path, and skill (PreToolUse/PostToolUse), last assistant message (Stop); steering rule files on disk
 - **Output:** Context injection with the body of all matching rules for context events (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, SubagentStart); block decision with rule body as reason for Stop events; silent if no rules match

--- a/hooks/SteeringRuleInjector/SteeringRuleInjector/IDEA.md
+++ b/hooks/SteeringRuleInjector/SteeringRuleInjector/IDEA.md
@@ -12,13 +12,15 @@ Store steering rules as individual markdown files with YAML frontmatter declarin
 
 ## How It Works
 
-1. Each steering rule is a markdown file with YAML frontmatter containing `name`, `events` (which hook events trigger it), and `keywords` (terms that activate it on prompt events).
-2. At session start, all rules declaring `SessionStart` in their events are injected as context.
-3. On each user prompt, the hook scans for rules declaring `UserPromptSubmit` and checks if any of their keywords appear in the prompt text.
-4. Matching rules have their markdown body (everything after the frontmatter) injected as context.
-5. Rules that do not match are silently skipped — zero cost when not triggered.
+1. Each steering rule is a markdown file with YAML frontmatter containing `name`, `events` (which hook events trigger it), and `keywords` (terms that activate it on keyword-matched events).
+2. On `SessionStart`, all rules declaring `SessionStart` with empty keywords inject automatically — always-on session-level rules.
+3. On `UserPromptSubmit`, rules declaring that event are checked against the prompt text; rules whose keywords appear in the text inject as context.
+4. On `PreToolUse` and `PostToolUse`, rules are matched against the tool name and file path; matching rules inject as `additionalContext` before or after the tool runs.
+5. On `SubagentStart`, rules with `SubagentStart` and empty keywords inject automatically, surfacing role and permission rules at the start of every subagent session.
+6. On `Stop`, rules are matched against the last assistant message; a match blocks the response with the rule body as the reason, forcing a retry.
+7. Rules already injected this session are skipped — each rule injects at most once per session via a per-session tracker file.
 
 ## Signals
 
-- **Input:** Hook event type, user prompt text (for UserPromptSubmit), steering rule files on disk
-- **Output:** Context injection containing the body of all matching steering rules, or silent if no rules match
+- **Input:** Hook event type; prompt text (UserPromptSubmit), tool name and file path (PreToolUse/PostToolUse), last assistant message (Stop); steering rule files on disk
+- **Output:** Context injection with the body of all matching rules for context events (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, SubagentStart); block decision with rule body as reason for Stop events; silent if no rules match

--- a/hooks/SteeringRuleInjector/SteeringRuleInjector/SteeringRuleInjector.contract.ts
+++ b/hooks/SteeringRuleInjector/SteeringRuleInjector/SteeringRuleInjector.contract.ts
@@ -2,7 +2,7 @@
  * SteeringRuleInjector Contract — Inject steering rules into session context.
  *
  * Fires on SessionStart, UserPromptSubmit, PreToolUse, PostToolUse,
- * SubagentStart, and PreCompact. Parses YAML frontmatter from .md rule files,
+ * SubagentStart, and Stop. Parses YAML frontmatter from .md rule files,
  * matches keywords case-insensitively, and tracks injections per-session so
  * each rule fires at most once.
  */
@@ -232,15 +232,6 @@ export const SteeringRuleInjector: SyncHookContract<SteeringRuleInput, SteeringR
     const matchText = getMatchText(input);
     const isToolEventType = eventType === "PreToolUse" || eventType === "PostToolUse";
 
-    // DEBUG: Log Stop input fields to diagnose blocking issue (remove after fix)
-    if (eventType === "Stop") {
-      const keys = Object.keys(input);
-      deps.stderr(`[SteeringRuleInjector] DEBUG Stop input keys: ${keys.join(", ")}`);
-      deps.stderr(
-        `[SteeringRuleInjector] DEBUG Stop matchText (first 100): ${matchText.slice(0, 100)}`,
-      );
-    }
-
     // Resolve glob patterns to file paths
     const filePaths = deps.resolveGlobs(config.includes);
     if (filePaths.length === 0) {
@@ -265,7 +256,7 @@ export const SteeringRuleInjector: SyncHookContract<SteeringRuleInput, SteeringR
       // Skip already-injected rules
       if (tracker.injected[rule.name]) continue;
 
-      // For always-events (SessionStart, SubagentStart, PreCompact), only inject empty-keyword rules
+      // For always-events (SessionStart, SubagentStart), only inject empty-keyword rules
       if (
         (eventType === "SessionStart" || eventType === "SubagentStart") &&
         rule.keywords.length > 0

--- a/hooks/SteeringRuleInjector/SteeringRuleInjector/doc.md
+++ b/hooks/SteeringRuleInjector/SteeringRuleInjector/doc.md
@@ -2,7 +2,7 @@
 
 Injects individual steering rule files into context based on event type and keyword matching. Rules are `.md` files with YAML frontmatter declaring when they should fire. Each rule injects at most once per session, tracked via a gitignored JSON file.
 
-Registered for `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `SubagentStart`, and `Stop`. Skips subagent sessions (except on `SubagentStart` itself).
+Registered for `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `SubagentStart`, and `Stop`. Skips subagent sessions.
 
 ## Event
 

--- a/hooks/SteeringRuleInjector/SteeringRuleInjector/doc.md
+++ b/hooks/SteeringRuleInjector/SteeringRuleInjector/doc.md
@@ -93,4 +93,3 @@ Rule content injected as context...
 - `core/adapters/fs` — `readFile`, `readJson`, `writeJson`, `fileExists` for rule and tracker I/O
 - `core/types/hook-input-schema` — Effect Schema for discriminated input parsing (replaces field-sniffing)
 - `Bun.Glob` — resolves include patterns to file paths
-- `Bun.Glob` — resolves include patterns to file paths


### PR DESCRIPTION
## Summary

- Remove DEBUG Stop logging block marked "remove after fix" from `SteeringRuleInjector.contract.ts`
- Fix stale file-header and inline comment referencing `PreCompact` (not in the event union)
- Remove duplicate `Bun.Glob` bullet in `doc.md` Dependencies section
- Rewrite `IDEA.md` How It Works and Signals to cover all 6 events: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, SubagentStart, Stop

## Test plan

- [x] `grep "DEBUG Stop" ...contract.ts` → no output
- [x] `grep "PreCompact" ...contract.ts` → no output
- [x] `grep -c "Bun.Glob" ...doc.md` → 1
- [x] `grep -c "PreToolUse|PostToolUse|SubagentStart|Stop" ...IDEA.md` → 5
- [x] `bun test hooks/SteeringRuleInjector` → 41 pass, 0 fail
- [x] `npx tsc --noEmit` → exits 0

Closes #132

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple