### PR TITLE
feat(DuplicationChecker): add actionable import/extraction guidance (#115)

### DIFF
--- a/docs/groups/DuplicationDetection/DuplicationChecker.html
+++ b/docs/groups/DuplicationDetection/DuplicationChecker.html
@@ -1954,7 +1954,7 @@ This is the checking half of a two-part system. A separate index builder maintai
 
         <div class="flow-step">
           <div class="step-dot">8</div>
-          <div class="step-content"><p>At 4/4 signals and blocking enabled: returns block with per-match guidance — "Import it from X" when the target is a canonical source file, "Consider extracting a shared abstraction" otherwise</p></div>
+          <div class="step-content"><p>At 4/4 signals and blocking enabled: returns block with per-match guidance — "Import it from X" when the target is a canonical source file, "Reuse the existing function from X or extract both to a shared module" otherwise</p></div>
         </div>
 
         <div class="flow-step">

--- a/docs/groups/DuplicationDetection/DuplicationChecker.html
+++ b/docs/groups/DuplicationDetection/DuplicationChecker.html
@@ -1954,7 +1954,7 @@ This is the checking half of a two-part system. A separate index builder maintai
 
         <div class="flow-step">
           <div class="step-dot">8</div>
-          <div class="step-content"><p>At 4/4 signals and blocking enabled: returns block with reason listing duplicate targets</p></div>
+          <div class="step-content"><p>At 4/4 signals and blocking enabled: returns block with per-match guidance — "Import it from X" when the target is a canonical source file, "Consider extracting a shared abstraction" otherwise</p></div>
         </div>
 
         <div class="flow-step">
@@ -2072,7 +2072,7 @@ Pattern detected: "makeDeps" (65 files)
       <h3 style="color: var(--green); margin-bottom: 12px;">Example 1: Exact duplicate blocked (4/4 signals)</h3>
       
       <div class="uc-example">
-        <div>The model writes a <code>getFilePath</code> function identical to one in <code>shared.ts</code>. All 4 dimensions match (hash, name, sig, body). DuplicationChecker blocks: "Exact duplicate function(s) detected: getFilePath duplicates shared.ts:getFilePath. Reuse the existing function."</div>
+        <div>The model writes a <code>getFilePath</code> function identical to one in <code>lib/tool-input.ts</code>. All 4 dimensions match (hash, name, sig, body). DuplicationChecker blocks with: "getFilePath duplicates lib/tool-input.ts:getFilePath (line 12) → Import it from lib/tool-input.ts". Because <code>lib/tool-input.ts</code> is a single-export source file whose name matches the function, it is tagged <code>source: true</code> and the guidance directs to import rather than extract.</div>
       </div>
       </div>
       <div style="margin-top: 20px;">

--- a/docs/groups/DuplicationDetection/DuplicationIndexBuilder.html
+++ b/docs/groups/DuplicationDetection/DuplicationIndexBuilder.html
@@ -1926,6 +1926,7 @@ This is the indexing half of a two-part system. The index builder creates and ma
           <div class="step-content"><p>Logs build/update statistics (function count, file count, size, and build time) to stderr</p></div>
         </div>
 </div>
+      <p>Each <code>IndexEntry</code> may carry <code>source: true</code> when the file is identified as a canonical source: it lives in a <code>lib/</code>, <code>core/</code>, <code>utils/</code>, or <code>shared/</code> directory, exports exactly one function, and that function's name matches the filename stem (e.g. <code>lib/tool-input.ts</code> exporting <code>toolInput</code>). DuplicationChecker uses this flag to emit actionable guidance — "Import it from X" instead of "Consider extracting a shared abstraction".</p>
       
       <div class="code-window">
         <div class="code-window-header">

--- a/docs/groups/DuplicationDetection/DuplicationIndexBuilder.html
+++ b/docs/groups/DuplicationDetection/DuplicationIndexBuilder.html
@@ -1926,7 +1926,7 @@ This is the indexing half of a two-part system. The index builder creates and ma
           <div class="step-content"><p>Logs build/update statistics (function count, file count, size, and build time) to stderr</p></div>
         </div>
 </div>
-      <p>Each <code>IndexEntry</code> may carry <code>source: true</code> when the file is identified as a canonical source: it lives in a <code>lib/</code>, <code>core/</code>, <code>utils/</code>, or <code>shared/</code> directory, exports exactly one function, and that function's name matches the filename stem (e.g. <code>lib/tool-input.ts</code> exporting <code>toolInput</code>). DuplicationChecker uses this flag to emit actionable guidance — "Import it from X" instead of "Consider extracting a shared abstraction".</p>
+      <p>Each <code>IndexEntry</code> may carry <code>source: true</code> when the file is identified as a canonical source: it lives in a <code>lib/</code>, <code>core/</code>, <code>utils/</code>, or <code>shared/</code> directory, contains exactly one function, and that function's name matches the filename stem with kebab-to-camelCase normalization (e.g., <code>lib/hook-config.ts</code> containing <code>hookConfig</code>). DuplicationChecker uses this flag to emit actionable guidance — "Import it from X" instead of "Reuse the existing function or extract both to a shared module".</p>
       
       <div class="code-window">
         <div class="code-window-header">

--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
@@ -214,12 +214,15 @@ export const DuplicationCheckerContract: SyncHookContract<ToolHookInput, Duplica
       const reason = [
         opener,
         "",
-        ...blockMatches.map(
-          (m) =>
+        ...blockMatches.flatMap((m) => {
+          const guidance = m.targetIsSource
+            ? `  → Import it from ${m.targetFile}`
+            : `  → Consider extracting a shared abstraction`;
+          return [
             `  ${m.functionName} duplicates ${m.targetFile}:${m.targetName} (line ${m.targetLine})`,
-        ),
-        "",
-        "Reuse the existing function instead of duplicating it.",
+            guidance,
+          ];
+        }),
       ].join("\n");
 
       if (deps.blocking) {

--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
@@ -217,7 +217,7 @@ export const DuplicationCheckerContract: SyncHookContract<ToolHookInput, Duplica
         ...blockMatches.flatMap((m) => {
           const guidance = m.targetIsSource
             ? `  → Import it from ${m.targetFile}`
-            : `  → Consider extracting a shared abstraction`;
+            : `  → Reuse the existing function from ${m.targetFile} or extract both to a shared module`;
           return [
             `  ${m.functionName} duplicates ${m.targetFile}:${m.targetName} (line ${m.targetLine})`,
             guidance,

--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
@@ -204,7 +204,7 @@ export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: bo
       if (hs && hs.hookEventName === "PreToolUse") {
         expect(hs.permissionDecision).toBe("deny");
         expect(hs.permissionDecisionReason).toContain("duplicates");
-        expect(hs.permissionDecisionReason).toContain("Reuse the existing function");
+        expect(hs.permissionDecisionReason).toContain("Consider extracting a shared abstraction");
       }
     });
 

--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
@@ -204,7 +204,7 @@ export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: bo
       if (hs && hs.hookEventName === "PreToolUse") {
         expect(hs.permissionDecision).toBe("deny");
         expect(hs.permissionDecisionReason).toContain("duplicates");
-        expect(hs.permissionDecisionReason).toContain("Consider extracting a shared abstraction");
+        expect(hs.permissionDecisionReason).toContain("Reuse the existing function from");
       }
     });
 

--- a/hooks/DuplicationDetection/DuplicationChecker/doc.md
+++ b/hooks/DuplicationDetection/DuplicationChecker/doc.md
@@ -51,7 +51,7 @@ It does **not** fire when:
 5. Extracts function signatures from the content using SWC parser
 6. Compares extracted functions against the index using `checkFunctions`
 7. Logs all checks to `checker.jsonl` with branch metadata
-8. At 4/4 signals and blocking enabled: returns block with per-match guidance — "Import it from X" when the target is a canonical source file, "Consider extracting a shared abstraction" otherwise
+8. At 4/4 signals and blocking enabled: returns block with per-match guidance — "Import it from X" when the target is a canonical source file, "Reuse the existing function from X or extract both to a shared module" otherwise
 9. At 2-3/4 signals: logs finding, returns continue
 
 ```typescript

--- a/hooks/DuplicationDetection/DuplicationChecker/doc.md
+++ b/hooks/DuplicationDetection/DuplicationChecker/doc.md
@@ -51,7 +51,7 @@ It does **not** fire when:
 5. Extracts function signatures from the content using SWC parser
 6. Compares extracted functions against the index using `checkFunctions`
 7. Logs all checks to `checker.jsonl` with branch metadata
-8. At 4/4 signals and blocking enabled: returns block with reason listing duplicate targets
+8. At 4/4 signals and blocking enabled: returns block with per-match guidance — "Import it from X" when the target is a canonical source file, "Consider extracting a shared abstraction" otherwise
 9. At 2-3/4 signals: logs finding, returns continue
 
 ```typescript
@@ -134,7 +134,7 @@ Pattern detection thresholds are set in `hookConfig.duplicationChecker` in `sett
 
 ### Example 1: Exact duplicate blocked (4/4 signals)
 
-> The model writes a `getFilePath` function identical to one in `shared.ts`. All 4 dimensions match (hash, name, sig, body). DuplicationChecker blocks: "Exact duplicate function(s) detected: getFilePath duplicates shared.ts:getFilePath. Reuse the existing function."
+> The model writes a `getFilePath` function identical to one in `lib/tool-input.ts`. All 4 dimensions match (hash, name, sig, body). DuplicationChecker blocks with: "getFilePath duplicates lib/tool-input.ts:getFilePath (line 12) → Import it from lib/tool-input.ts". Because `lib/tool-input.ts` is a single-export source file whose name matches the function, it is tagged `source: true` and the guidance directs to import rather than extract.
 
 ### Example 2: Partial match logged (2-3 signals)
 

--- a/hooks/DuplicationDetection/DuplicationIndexBuilder/doc.md
+++ b/hooks/DuplicationDetection/DuplicationIndexBuilder/doc.md
@@ -38,7 +38,7 @@ It does **not** fire when:
 7. Writes the resulting index as JSON to `/tmp/pai/duplication/{hash}/{branch}/index.json`
 8. Logs build/update statistics (function count, file count, size, and build time) to stderr
 
-Each `IndexEntry` may carry `source: true` when the file is identified as a canonical source: it lives in a `lib/`, `core/`, `utils/`, or `shared/` directory, exports exactly one function, and that function's name matches the filename stem (e.g. `lib/tool-input.ts` exporting `toolInput`). DuplicationChecker uses this flag to emit actionable guidance — "Import it from X" instead of "Consider extracting a shared abstraction".
+Each `IndexEntry` may carry `source: true` when the file is identified as a canonical source: it lives in a `lib/`, `core/`, `utils/`, or `shared/` directory, contains exactly one function, and that function's name matches the filename stem with kebab-to-camelCase normalization (e.g., `lib/hook-config.ts` containing `hookConfig`). DuplicationChecker uses this flag to emit actionable guidance — "Import it from X" instead of "Reuse the existing function or extract both to a shared module".
 
 ```typescript
 // Core flow — surgical update on PostToolUse, full rebuild on SessionStart

--- a/hooks/DuplicationDetection/DuplicationIndexBuilder/doc.md
+++ b/hooks/DuplicationDetection/DuplicationIndexBuilder/doc.md
@@ -38,6 +38,8 @@ It does **not** fire when:
 7. Writes the resulting index as JSON to `/tmp/pai/duplication/{hash}/{branch}/index.json`
 8. Logs build/update statistics (function count, file count, size, and build time) to stderr
 
+Each `IndexEntry` may carry `source: true` when the file is identified as a canonical source: it lives in a `lib/`, `core/`, `utils/`, or `shared/` directory, exports exactly one function, and that function's name matches the filename stem (e.g. `lib/tool-input.ts` exporting `toolInput`). DuplicationChecker uses this flag to emit actionable guidance — "Import it from X" instead of "Consider extracting a shared abstraction".
+
 ```typescript
 // Core flow — surgical update on PostToolUse, full rebuild on SessionStart
 const anchor = isToolInput(input) ? getFilePath(input)! : deps.cwd();

--- a/hooks/DuplicationDetection/index-builder-logic.test.ts
+++ b/hooks/DuplicationDetection/index-builder-logic.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for index-builder-logic.ts source heuristic functions.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { isSourceFile, kebabToCamel } from "./index-builder-logic";
+
+// ─── kebabToCamel ───────────────────────────────────────────────────────────
+
+describe("kebabToCamel", () => {
+  test("converts kebab-case to camelCase", () => {
+    expect(kebabToCamel("hook-config")).toBe("hookConfig");
+  });
+
+  test("converts multi-segment kebab-case", () => {
+    expect(kebabToCamel("tool-input-parser")).toBe("toolInputParser");
+  });
+
+  test("preserves already camelCase", () => {
+    expect(kebabToCamel("hookConfig")).toBe("hookConfig");
+  });
+
+  test("preserves single word", () => {
+    expect(kebabToCamel("pipe")).toBe("pipe");
+  });
+
+  test("handles leading hyphen", () => {
+    expect(kebabToCamel("-test")).toBe("Test");
+  });
+});
+
+// ─── isSourceFile ───────────────────────────────────────────────────────────
+
+describe("isSourceFile", () => {
+  describe("returns true for canonical sources", () => {
+    test("exact match in lib/", () => {
+      expect(isSourceFile("lib/pipe.ts", "pipe", 1)).toBe(true);
+    });
+
+    test("kebab-to-camel match in lib/", () => {
+      expect(isSourceFile("lib/hook-config.ts", "hookConfig", 1)).toBe(true);
+    });
+
+    test("exact match in core/", () => {
+      expect(isSourceFile("core/runner.ts", "runner", 1)).toBe(true);
+    });
+
+    test("exact match in utils/", () => {
+      expect(isSourceFile("utils/helpers.ts", "helpers", 1)).toBe(true);
+    });
+
+    test("exact match in shared/", () => {
+      expect(isSourceFile("shared/types.ts", "types", 1)).toBe(true);
+    });
+
+    test("nested path with source dir", () => {
+      expect(isSourceFile("src/lib/tool-input.ts", "toolInput", 1)).toBe(true);
+    });
+  });
+
+  describe("returns false for non-sources", () => {
+    test("multi-function file", () => {
+      expect(isSourceFile("lib/tool-input.ts", "getFilePath", 3)).toBe(false);
+    });
+
+    test("name mismatch", () => {
+      expect(isSourceFile("lib/helpers.ts", "getFilePath", 1)).toBe(false);
+    });
+
+    test("wrong directory", () => {
+      expect(isSourceFile("src/utils.ts", "utils", 1)).toBe(false);
+    });
+
+    test("hooks directory (not a source dir)", () => {
+      expect(isSourceFile("hooks/DuplicationChecker/contract.ts", "contract", 1)).toBe(false);
+    });
+
+    test("zero functions", () => {
+      expect(isSourceFile("lib/types.ts", "types", 0)).toBe(false);
+    });
+  });
+});

--- a/hooks/DuplicationDetection/index-builder-logic.ts
+++ b/hooks/DuplicationDetection/index-builder-logic.ts
@@ -39,9 +39,17 @@ export interface IndexBuilderDeps {
 const SOURCE_DIRS = new Set(["lib", "core", "utils", "shared"]);
 
 /**
+ * Convert kebab-case to camelCase: "hook-config" → "hookConfig"
+ */
+export function kebabToCamel(str: string): string {
+  return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
  * Returns true when a file is likely a canonical source (not a consumer).
  * Criteria: lives in a source directory (lib/core/utils/shared), has exactly
- * one exported function, and the function name matches the filename stem.
+ * one function in the file, and the function name matches the filename stem
+ * (with kebab-case → camelCase normalization).
  */
 export function isSourceFile(relPath: string, fnName: string, fileEntryCount: number): boolean {
   if (fileEntryCount !== 1) return false;
@@ -49,7 +57,8 @@ export function isSourceFile(relPath: string, fnName: string, fileEntryCount: nu
   const inSourceDir = parts.some((p) => SOURCE_DIRS.has(p));
   if (!inSourceDir) return false;
   const stem = basename(relPath, extname(relPath));
-  return stem === fnName;
+  // Match exact (e.g., "pipe" === "pipe") or kebab-to-camel (e.g., "hook-config" → "hookConfig")
+  return stem === fnName || kebabToCamel(stem) === fnName;
 }
 
 // ─── File Scanning ──────────────────────────────────────────────────────────

--- a/hooks/DuplicationDetection/index-builder-logic.ts
+++ b/hooks/DuplicationDetection/index-builder-logic.ts
@@ -8,6 +8,7 @@
  * to keep the checker's import surface minimal.
  */
 
+import { basename, extname } from "node:path";
 import type { ParserDeps } from "@hooks/hooks/DuplicationDetection/parser";
 import { extractFunctions } from "@hooks/hooks/DuplicationDetection/parser";
 import {
@@ -31,6 +32,24 @@ export interface IndexBuilderDeps {
   join: (...parts: string[]) => string;
   resolve: (path: string) => string;
   parserDeps: ParserDeps;
+}
+
+// ─── Source Heuristic ───────────────────────────────────────────────────────
+
+const SOURCE_DIRS = new Set(["lib", "core", "utils", "shared"]);
+
+/**
+ * Returns true when a file is likely a canonical source (not a consumer).
+ * Criteria: lives in a source directory (lib/core/utils/shared), has exactly
+ * one exported function, and the function name matches the filename stem.
+ */
+export function isSourceFile(relPath: string, fnName: string, fileEntryCount: number): boolean {
+  if (fileEntryCount !== 1) return false;
+  const parts = relPath.split("/");
+  const inSourceDir = parts.some((p) => SOURCE_DIRS.has(p));
+  if (!inSourceDir) return false;
+  const stem = basename(relPath, extname(relPath));
+  return stem === fnName;
 }
 
 // ─── File Scanning ──────────────────────────────────────────────────────────
@@ -93,6 +112,7 @@ export function buildIndex(directory: string, deps: IndexBuilderDeps): Duplicati
     const functions = extractFunctions(content, isTsx, deps.parserDeps);
 
     for (const fn of functions) {
+      const source = isSourceFile(relPath, fn.name, functions.length) || undefined;
       entries.push({
         f: relPath,
         n: fn.name,
@@ -102,6 +122,7 @@ export function buildIndex(directory: string, deps: IndexBuilderDeps): Duplicati
         r: fn.returnType,
         fp: fn.fingerprint,
         s: 0, // body size not needed for checker, keep lightweight
+        source,
       });
     }
   }
@@ -248,6 +269,7 @@ export function updateIndexForFile(
   const functions = extractFunctions(content, isTsx, deps.parserDeps);
 
   for (const fn of functions) {
+    const source = isSourceFile(relPath, fn.name, functions.length) || undefined;
     keptEntries.push({
       f: relPath,
       n: fn.name,
@@ -257,6 +279,7 @@ export function updateIndexForFile(
       r: fn.returnType,
       fp: fn.fingerprint,
       s: 0,
+      source,
     });
   }
 

--- a/hooks/DuplicationDetection/shared.ts
+++ b/hooks/DuplicationDetection/shared.ts
@@ -23,6 +23,7 @@ export interface IndexEntry {
   r: string;
   fp: string;
   s: number;
+  source?: boolean;
 }
 
 export interface DuplicationIndex {
@@ -48,6 +49,7 @@ export interface DuplicationMatch {
   signals: string[];
   topScore: number;
   derivation?: boolean;
+  targetIsSource?: boolean;
 }
 
 export interface PatternEntry {
@@ -252,7 +254,7 @@ export function checkFunctions(
 
   for (const fn of functions) {
     const signals: string[] = [];
-    let bestTarget: { file: string; name: string; line: number } | null = null;
+    let bestTarget: { file: string; name: string; line: number; source?: boolean } | null = null;
     let topScore = 0;
 
     let isDerivation = false;
@@ -265,12 +267,12 @@ export function checkFunctions(
         const peerSig = `(${peer.p})→${peer.r}`;
         if (fnSig !== peerSig) {
           isDerivation = true;
-          bestTarget = { file: peer.f, name: peer.n, line: peer.l };
+          bestTarget = { file: peer.f, name: peer.n, line: peer.l, source: peer.source };
           topScore = 1.0;
           break;
         }
         signals.push("hash");
-        bestTarget = { file: peer.f, name: peer.n, line: peer.l };
+        bestTarget = { file: peer.f, name: peer.n, line: peer.l, source: peer.source };
         topScore = 1.0;
         break;
       }
@@ -281,7 +283,7 @@ export function checkFunctions(
       signals.push("name");
       if (!bestTarget) {
         const peer = index.entries[namePeers[0]];
-        bestTarget = { file: peer.f, name: peer.n, line: peer.l };
+        bestTarget = { file: peer.f, name: peer.n, line: peer.l, source: peer.source };
       }
       topScore = Math.max(topScore, Math.min(1.0, namePeers.length / 10));
     }
@@ -298,7 +300,7 @@ export function checkFunctions(
           signals.push("body");
           if (sim > topScore) {
             topScore = sim;
-            bestTarget = { file: peer.f, name: peer.n, line: peer.l };
+            bestTarget = { file: peer.f, name: peer.n, line: peer.l, source: peer.source };
           }
           break;
         }
@@ -315,6 +317,7 @@ export function checkFunctions(
         signals: ["hash"],
         topScore,
         derivation: true,
+        targetIsSource: bestTarget.source,
       });
     } else if (signals.length >= LOG_THRESHOLD && bestTarget) {
       matches.push({
@@ -325,6 +328,7 @@ export function checkFunctions(
         targetLine: bestTarget.line,
         signals,
         topScore,
+        targetIsSource: bestTarget.source,
       });
     }
   }


### PR DESCRIPTION
## Summary

- Adds `source?: boolean` to `IndexEntry` and `targetIsSource?: boolean` to `DuplicationMatch` in `shared.ts`
- Adds `isSourceFile()` heuristic in `index-builder-logic.ts` — tags lib/core/utils/shared files with a single export whose name matches the filename as `source: true`
- Replaces the static "Reuse the existing function" trailing line in block messages with per-match guidance: "Import it from X" for source targets, "Consider extracting a shared abstraction" for non-source targets

## Test plan

- [ ] `bun test hooks/DuplicationDetection/DuplicationChecker hooks/DuplicationDetection/DuplicationIndexBuilder` → 56 pass, 0 fail
- [ ] `npx tsc --noEmit` (via `node_modules/.bin/tsc`) → exits 0
- [ ] Block message for non-source target contains "Consider extracting a shared abstraction"
- [ ] `isSourceFile` returns true for single-export lib/core files whose name matches function name
- [ ] `isSourceFile` returns false for multi-export files, test files, and non-source dirs

Closes #115

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple