### PR TITLE
fix(docs): prevent hook count badge bleed (#113)

### DIFF
--- a/docs/groups/AgentLifecycle/AgentExecutionGuard.html
+++ b/docs/groups/AgentLifecycle/AgentExecutionGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/AgentLifecycle/AgentExecutionGuard.html
+++ b/docs/groups/AgentLifecycle/AgentExecutionGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/AgentLifecycle/AgentLifecycleStart.html
+++ b/docs/groups/AgentLifecycle/AgentLifecycleStart.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/AgentLifecycle/AgentLifecycleStart.html
+++ b/docs/groups/AgentLifecycle/AgentLifecycleStart.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/AgentLifecycle/AgentLifecycleStop.html
+++ b/docs/groups/AgentLifecycle/AgentLifecycleStop.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/AgentLifecycle/AgentLifecycleStop.html
+++ b/docs/groups/AgentLifecycle/AgentLifecycleStop.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/AgentLifecycle/index.html
+++ b/docs/groups/AgentLifecycle/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/AgentLifecycle/index.html
+++ b/docs/groups/AgentLifecycle/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/AlgorithmTracking/AlgorithmTracker.html
+++ b/docs/groups/AlgorithmTracking/AlgorithmTracker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/AlgorithmTracking/AlgorithmTracker.html
+++ b/docs/groups/AlgorithmTracking/AlgorithmTracker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/AlgorithmTracking/CheckAlgorithmVersion.html
+++ b/docs/groups/AlgorithmTracking/CheckAlgorithmVersion.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/AlgorithmTracking/CheckAlgorithmVersion.html
+++ b/docs/groups/AlgorithmTracking/CheckAlgorithmVersion.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/AlgorithmTracking/index.html
+++ b/docs/groups/AlgorithmTracking/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/AlgorithmTracking/index.html
+++ b/docs/groups/AlgorithmTracking/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ArchitectureEscalation/ArchitectureEscalation.html
+++ b/docs/groups/ArchitectureEscalation/ArchitectureEscalation.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ArchitectureEscalation/ArchitectureEscalation.html
+++ b/docs/groups/ArchitectureEscalation/ArchitectureEscalation.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ArchitectureEscalation/SonnetDelegation.html
+++ b/docs/groups/ArchitectureEscalation/SonnetDelegation.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ArchitectureEscalation/SonnetDelegation.html
+++ b/docs/groups/ArchitectureEscalation/SonnetDelegation.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ArchitectureEscalation/index.html
+++ b/docs/groups/ArchitectureEscalation/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ArchitectureEscalation/index.html
+++ b/docs/groups/ArchitectureEscalation/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CanaryHook/CanaryHook.html
+++ b/docs/groups/CanaryHook/CanaryHook.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CanaryHook/CanaryHook.html
+++ b/docs/groups/CanaryHook/CanaryHook.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CanaryHook/index.html
+++ b/docs/groups/CanaryHook/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CanaryHook/index.html
+++ b/docs/groups/CanaryHook/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodeQualityPipeline/CodeQualityBaseline.html
+++ b/docs/groups/CodeQualityPipeline/CodeQualityBaseline.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodeQualityPipeline/CodeQualityBaseline.html
+++ b/docs/groups/CodeQualityPipeline/CodeQualityBaseline.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodeQualityPipeline/CodeQualityGuard.html
+++ b/docs/groups/CodeQualityPipeline/CodeQualityGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodeQualityPipeline/CodeQualityGuard.html
+++ b/docs/groups/CodeQualityPipeline/CodeQualityGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodeQualityPipeline/SessionQualityReport.html
+++ b/docs/groups/CodeQualityPipeline/SessionQualityReport.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodeQualityPipeline/SessionQualityReport.html
+++ b/docs/groups/CodeQualityPipeline/SessionQualityReport.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodeQualityPipeline/index.html
+++ b/docs/groups/CodeQualityPipeline/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodeQualityPipeline/index.html
+++ b/docs/groups/CodeQualityPipeline/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodingStandards/BashWriteGuard.html
+++ b/docs/groups/CodingStandards/BashWriteGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodingStandards/BashWriteGuard.html
+++ b/docs/groups/CodingStandards/BashWriteGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodingStandards/CodingStandardsAdvisor.html
+++ b/docs/groups/CodingStandards/CodingStandardsAdvisor.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodingStandards/CodingStandardsAdvisor.html
+++ b/docs/groups/CodingStandards/CodingStandardsAdvisor.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodingStandards/CodingStandardsEnforcer.html
+++ b/docs/groups/CodingStandards/CodingStandardsEnforcer.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodingStandards/CodingStandardsEnforcer.html
+++ b/docs/groups/CodingStandards/CodingStandardsEnforcer.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodingStandards/DocCommitGuard.html
+++ b/docs/groups/CodingStandards/DocCommitGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodingStandards/DocCommitGuard.html
+++ b/docs/groups/CodingStandards/DocCommitGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodingStandards/TypeCheckVerifier.html
+++ b/docs/groups/CodingStandards/TypeCheckVerifier.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodingStandards/TypeCheckVerifier.html
+++ b/docs/groups/CodingStandards/TypeCheckVerifier.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodingStandards/TypeStrictness.html
+++ b/docs/groups/CodingStandards/TypeStrictness.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodingStandards/TypeStrictness.html
+++ b/docs/groups/CodingStandards/TypeStrictness.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodingStandards/WhileLoopGuard.html
+++ b/docs/groups/CodingStandards/WhileLoopGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodingStandards/WhileLoopGuard.html
+++ b/docs/groups/CodingStandards/WhileLoopGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CodingStandards/index.html
+++ b/docs/groups/CodingStandards/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CodingStandards/index.html
+++ b/docs/groups/CodingStandards/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CronStatusLine/CronCreate.html
+++ b/docs/groups/CronStatusLine/CronCreate.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CronStatusLine/CronCreate.html
+++ b/docs/groups/CronStatusLine/CronCreate.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CronStatusLine/CronDelete.html
+++ b/docs/groups/CronStatusLine/CronDelete.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CronStatusLine/CronDelete.html
+++ b/docs/groups/CronStatusLine/CronDelete.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CronStatusLine/CronFire.html
+++ b/docs/groups/CronStatusLine/CronFire.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CronStatusLine/CronFire.html
+++ b/docs/groups/CronStatusLine/CronFire.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CronStatusLine/CronPrune.html
+++ b/docs/groups/CronStatusLine/CronPrune.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CronStatusLine/CronPrune.html
+++ b/docs/groups/CronStatusLine/CronPrune.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CronStatusLine/CronSessionEnd.html
+++ b/docs/groups/CronStatusLine/CronSessionEnd.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CronStatusLine/CronSessionEnd.html
+++ b/docs/groups/CronStatusLine/CronSessionEnd.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/CronStatusLine/index.html
+++ b/docs/groups/CronStatusLine/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/CronStatusLine/index.html
+++ b/docs/groups/CronStatusLine/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/DuplicationDetection/DuplicationChecker.html
+++ b/docs/groups/DuplicationDetection/DuplicationChecker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/DuplicationDetection/DuplicationChecker.html
+++ b/docs/groups/DuplicationDetection/DuplicationChecker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/DuplicationDetection/DuplicationIndexBuilder.html
+++ b/docs/groups/DuplicationDetection/DuplicationIndexBuilder.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/DuplicationDetection/DuplicationIndexBuilder.html
+++ b/docs/groups/DuplicationDetection/DuplicationIndexBuilder.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/DuplicationDetection/index.html
+++ b/docs/groups/DuplicationDetection/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/DuplicationDetection/index.html
+++ b/docs/groups/DuplicationDetection/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ExecutionEvidence/ExecutionEvidenceVerifier.html
+++ b/docs/groups/ExecutionEvidence/ExecutionEvidenceVerifier.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ExecutionEvidence/ExecutionEvidenceVerifier.html
+++ b/docs/groups/ExecutionEvidence/ExecutionEvidenceVerifier.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ExecutionEvidence/index.html
+++ b/docs/groups/ExecutionEvidence/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ExecutionEvidence/index.html
+++ b/docs/groups/ExecutionEvidence/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/GitSafety/ApprovalGate.html
+++ b/docs/groups/GitSafety/ApprovalGate.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/GitSafety/ApprovalGate.html
+++ b/docs/groups/GitSafety/ApprovalGate.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/GitSafety/DestructiveDeleteGuard.html
+++ b/docs/groups/GitSafety/DestructiveDeleteGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/GitSafety/DestructiveDeleteGuard.html
+++ b/docs/groups/GitSafety/DestructiveDeleteGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/GitSafety/GitAutoSync.html
+++ b/docs/groups/GitSafety/GitAutoSync.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/GitSafety/GitAutoSync.html
+++ b/docs/groups/GitSafety/GitAutoSync.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/GitSafety/HookExecutePermission.html
+++ b/docs/groups/GitSafety/HookExecutePermission.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/GitSafety/HookExecutePermission.html
+++ b/docs/groups/GitSafety/HookExecutePermission.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/GitSafety/MergeGate.html
+++ b/docs/groups/GitSafety/MergeGate.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/GitSafety/MergeGate.html
+++ b/docs/groups/GitSafety/MergeGate.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/GitSafety/ProtectedBranchGuard.html
+++ b/docs/groups/GitSafety/ProtectedBranchGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/GitSafety/ProtectedBranchGuard.html
+++ b/docs/groups/GitSafety/ProtectedBranchGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/GitSafety/WorktreeSafetyVerification.html
+++ b/docs/groups/GitSafety/WorktreeSafetyVerification.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/GitSafety/WorktreeSafetyVerification.html
+++ b/docs/groups/GitSafety/WorktreeSafetyVerification.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/GitSafety/index.html
+++ b/docs/groups/GitSafety/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/GitSafety/index.html
+++ b/docs/groups/GitSafety/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/IdentityBranding/MapleBranding.html
+++ b/docs/groups/IdentityBranding/MapleBranding.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/IdentityBranding/MapleBranding.html
+++ b/docs/groups/IdentityBranding/MapleBranding.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/IdentityBranding/ModeAnalytics.html
+++ b/docs/groups/IdentityBranding/ModeAnalytics.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/IdentityBranding/ModeAnalytics.html
+++ b/docs/groups/IdentityBranding/ModeAnalytics.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/IdentityBranding/UpdateCounts.html
+++ b/docs/groups/IdentityBranding/UpdateCounts.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/IdentityBranding/UpdateCounts.html
+++ b/docs/groups/IdentityBranding/UpdateCounts.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/IdentityBranding/index.html
+++ b/docs/groups/IdentityBranding/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/IdentityBranding/index.html
+++ b/docs/groups/IdentityBranding/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/KoordDaemon/AgentCompleteTracker.html
+++ b/docs/groups/KoordDaemon/AgentCompleteTracker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/KoordDaemon/AgentCompleteTracker.html
+++ b/docs/groups/KoordDaemon/AgentCompleteTracker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/KoordDaemon/AgentPrepromptInjector.html
+++ b/docs/groups/KoordDaemon/AgentPrepromptInjector.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/KoordDaemon/AgentPrepromptInjector.html
+++ b/docs/groups/KoordDaemon/AgentPrepromptInjector.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/KoordDaemon/AgentSpawnTracker.html
+++ b/docs/groups/KoordDaemon/AgentSpawnTracker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/KoordDaemon/AgentSpawnTracker.html
+++ b/docs/groups/KoordDaemon/AgentSpawnTracker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/KoordDaemon/MessageQueueRelay.html
+++ b/docs/groups/KoordDaemon/MessageQueueRelay.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/KoordDaemon/MessageQueueRelay.html
+++ b/docs/groups/KoordDaemon/MessageQueueRelay.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/KoordDaemon/MessageQueueServer.html
+++ b/docs/groups/KoordDaemon/MessageQueueServer.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/KoordDaemon/MessageQueueServer.html
+++ b/docs/groups/KoordDaemon/MessageQueueServer.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/KoordDaemon/SessionIdRegister.html
+++ b/docs/groups/KoordDaemon/SessionIdRegister.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/KoordDaemon/SessionIdRegister.html
+++ b/docs/groups/KoordDaemon/SessionIdRegister.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/KoordDaemon/index.html
+++ b/docs/groups/KoordDaemon/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/KoordDaemon/index.html
+++ b/docs/groups/KoordDaemon/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/LastResponseCache/LastResponseCache.html
+++ b/docs/groups/LastResponseCache/LastResponseCache.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/LastResponseCache/LastResponseCache.html
+++ b/docs/groups/LastResponseCache/LastResponseCache.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/LastResponseCache/index.html
+++ b/docs/groups/LastResponseCache/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/LastResponseCache/index.html
+++ b/docs/groups/LastResponseCache/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/LearningFeedback/LearningActioner.html
+++ b/docs/groups/LearningFeedback/LearningActioner.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/LearningFeedback/LearningActioner.html
+++ b/docs/groups/LearningFeedback/LearningActioner.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/LearningFeedback/RatingCapture.html
+++ b/docs/groups/LearningFeedback/RatingCapture.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/LearningFeedback/RatingCapture.html
+++ b/docs/groups/LearningFeedback/RatingCapture.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/LearningFeedback/RelationshipMemory.html
+++ b/docs/groups/LearningFeedback/RelationshipMemory.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/LearningFeedback/RelationshipMemory.html
+++ b/docs/groups/LearningFeedback/RelationshipMemory.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/LearningFeedback/index.html
+++ b/docs/groups/LearningFeedback/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/LearningFeedback/index.html
+++ b/docs/groups/LearningFeedback/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/CitationEnforcement.html
+++ b/docs/groups/ObligationStateMachines/CitationEnforcement.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/CitationEnforcement.html
+++ b/docs/groups/ObligationStateMachines/CitationEnforcement.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/CitationTracker.html
+++ b/docs/groups/ObligationStateMachines/CitationTracker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/CitationTracker.html
+++ b/docs/groups/ObligationStateMachines/CitationTracker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/DocObligationEnforcer.html
+++ b/docs/groups/ObligationStateMachines/DocObligationEnforcer.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/DocObligationEnforcer.html
+++ b/docs/groups/ObligationStateMachines/DocObligationEnforcer.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/DocObligationTracker.html
+++ b/docs/groups/ObligationStateMachines/DocObligationTracker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/DocObligationTracker.html
+++ b/docs/groups/ObligationStateMachines/DocObligationTracker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/HookDocEnforcer.html
+++ b/docs/groups/ObligationStateMachines/HookDocEnforcer.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/HookDocEnforcer.html
+++ b/docs/groups/ObligationStateMachines/HookDocEnforcer.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/HookDocTracker.html
+++ b/docs/groups/ObligationStateMachines/HookDocTracker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/HookDocTracker.html
+++ b/docs/groups/ObligationStateMachines/HookDocTracker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/SpotCheckReview.html
+++ b/docs/groups/ObligationStateMachines/SpotCheckReview.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/SpotCheckReview.html
+++ b/docs/groups/ObligationStateMachines/SpotCheckReview.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/TestObligationEnforcer.html
+++ b/docs/groups/ObligationStateMachines/TestObligationEnforcer.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/TestObligationEnforcer.html
+++ b/docs/groups/ObligationStateMachines/TestObligationEnforcer.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/TestObligationTracker.html
+++ b/docs/groups/ObligationStateMachines/TestObligationTracker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/TestObligationTracker.html
+++ b/docs/groups/ObligationStateMachines/TestObligationTracker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/ObligationStateMachines/index.html
+++ b/docs/groups/ObligationStateMachines/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/ObligationStateMachines/index.html
+++ b/docs/groups/ObligationStateMachines/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/QuestionAnswered/QuestionAnswered.html
+++ b/docs/groups/QuestionAnswered/QuestionAnswered.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/QuestionAnswered/QuestionAnswered.html
+++ b/docs/groups/QuestionAnswered/QuestionAnswered.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/QuestionAnswered/index.html
+++ b/docs/groups/QuestionAnswered/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/QuestionAnswered/index.html
+++ b/docs/groups/QuestionAnswered/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SecurityValidator/PermissionPromptLogger.html
+++ b/docs/groups/SecurityValidator/PermissionPromptLogger.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SecurityValidator/PermissionPromptLogger.html
+++ b/docs/groups/SecurityValidator/PermissionPromptLogger.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SecurityValidator/SecurityValidator.html
+++ b/docs/groups/SecurityValidator/SecurityValidator.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SecurityValidator/SecurityValidator.html
+++ b/docs/groups/SecurityValidator/SecurityValidator.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SecurityValidator/SettingsGuard.html
+++ b/docs/groups/SecurityValidator/SettingsGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SecurityValidator/SettingsGuard.html
+++ b/docs/groups/SecurityValidator/SettingsGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SecurityValidator/SettingsRevert.html
+++ b/docs/groups/SecurityValidator/SettingsRevert.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SecurityValidator/SettingsRevert.html
+++ b/docs/groups/SecurityValidator/SettingsRevert.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SecurityValidator/index.html
+++ b/docs/groups/SecurityValidator/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SecurityValidator/index.html
+++ b/docs/groups/SecurityValidator/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SessionFraming/BranchAwareness.html
+++ b/docs/groups/SessionFraming/BranchAwareness.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SessionFraming/BranchAwareness.html
+++ b/docs/groups/SessionFraming/BranchAwareness.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SessionFraming/CheckVersion.html
+++ b/docs/groups/SessionFraming/CheckVersion.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SessionFraming/CheckVersion.html
+++ b/docs/groups/SessionFraming/CheckVersion.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SessionFraming/GitignoreRecommender.html
+++ b/docs/groups/SessionFraming/GitignoreRecommender.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SessionFraming/GitignoreRecommender.html
+++ b/docs/groups/SessionFraming/GitignoreRecommender.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SessionFraming/LoadContext.html
+++ b/docs/groups/SessionFraming/LoadContext.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SessionFraming/LoadContext.html
+++ b/docs/groups/SessionFraming/LoadContext.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SessionFraming/index.html
+++ b/docs/groups/SessionFraming/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SessionFraming/index.html
+++ b/docs/groups/SessionFraming/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SkillGuard/SkillGuard.html
+++ b/docs/groups/SkillGuard/SkillGuard.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SkillGuard/SkillGuard.html
+++ b/docs/groups/SkillGuard/SkillGuard.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SkillGuard/index.html
+++ b/docs/groups/SkillGuard/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SkillGuard/index.html
+++ b/docs/groups/SkillGuard/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SteeringRuleInjector/SteeringRuleInjector.html
+++ b/docs/groups/SteeringRuleInjector/SteeringRuleInjector.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SteeringRuleInjector/SteeringRuleInjector.html
+++ b/docs/groups/SteeringRuleInjector/SteeringRuleInjector.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/SteeringRuleInjector/index.html
+++ b/docs/groups/SteeringRuleInjector/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/SteeringRuleInjector/index.html
+++ b/docs/groups/SteeringRuleInjector/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/StopOrchestrator/StopOrchestrator.html
+++ b/docs/groups/StopOrchestrator/StopOrchestrator.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/StopOrchestrator/StopOrchestrator.html
+++ b/docs/groups/StopOrchestrator/StopOrchestrator.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/StopOrchestrator/index.html
+++ b/docs/groups/StopOrchestrator/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/StopOrchestrator/index.html
+++ b/docs/groups/StopOrchestrator/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/VoiceGate/VoiceGate.html
+++ b/docs/groups/VoiceGate/VoiceGate.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/VoiceGate/VoiceGate.html
+++ b/docs/groups/VoiceGate/VoiceGate.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/VoiceGate/index.html
+++ b/docs/groups/VoiceGate/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/VoiceGate/index.html
+++ b/docs/groups/VoiceGate/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WikiPipeline/WikiContextInjector.html
+++ b/docs/groups/WikiPipeline/WikiContextInjector.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WikiPipeline/WikiContextInjector.html
+++ b/docs/groups/WikiPipeline/WikiContextInjector.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WikiPipeline/WikiIngest.html
+++ b/docs/groups/WikiPipeline/WikiIngest.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WikiPipeline/WikiIngest.html
+++ b/docs/groups/WikiPipeline/WikiIngest.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WikiPipeline/WikiReadTracker.html
+++ b/docs/groups/WikiPipeline/WikiReadTracker.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WikiPipeline/WikiReadTracker.html
+++ b/docs/groups/WikiPipeline/WikiReadTracker.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WikiPipeline/index.html
+++ b/docs/groups/WikiPipeline/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WikiPipeline/index.html
+++ b/docs/groups/WikiPipeline/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WorkLifecycle/ArticleWriter.html
+++ b/docs/groups/WorkLifecycle/ArticleWriter.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WorkLifecycle/ArticleWriter.html
+++ b/docs/groups/WorkLifecycle/ArticleWriter.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WorkLifecycle/AutoWorkCreation.html
+++ b/docs/groups/WorkLifecycle/AutoWorkCreation.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WorkLifecycle/AutoWorkCreation.html
+++ b/docs/groups/WorkLifecycle/AutoWorkCreation.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WorkLifecycle/PRDSync.html
+++ b/docs/groups/WorkLifecycle/PRDSync.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WorkLifecycle/PRDSync.html
+++ b/docs/groups/WorkLifecycle/PRDSync.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WorkLifecycle/PreCompactStatePersist.html
+++ b/docs/groups/WorkLifecycle/PreCompactStatePersist.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WorkLifecycle/PreCompactStatePersist.html
+++ b/docs/groups/WorkLifecycle/PreCompactStatePersist.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WorkLifecycle/SessionSummary.html
+++ b/docs/groups/WorkLifecycle/SessionSummary.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WorkLifecycle/SessionSummary.html
+++ b/docs/groups/WorkLifecycle/SessionSummary.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WorkLifecycle/WorkCompletionLearning.html
+++ b/docs/groups/WorkLifecycle/WorkCompletionLearning.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WorkLifecycle/WorkCompletionLearning.html
+++ b/docs/groups/WorkLifecycle/WorkCompletionLearning.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/groups/WorkLifecycle/index.html
+++ b/docs/groups/WorkLifecycle/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/groups/WorkLifecycle/index.html
+++ b/docs/groups/WorkLifecycle/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/docs/index.html
+++ b/docs/index.html
@@ -536,8 +536,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/docs/index.html
+++ b/docs/index.html
@@ -524,6 +524,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;
@@ -1774,7 +1775,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>AgentLifecycle</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
         </div>
         <p>Agent spawn, stop, and permission management</p>
       </div>
@@ -1783,7 +1784,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>AlgorithmTracking</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span></div>
         </div>
         <p>PAI Algorithm phase detection</p>
       </div>
@@ -1792,7 +1793,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>ArchitectureEscalation</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span></div>
         </div>
         <p>Failure escalation and model delegation</p>
       </div>
@@ -1801,7 +1802,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>CanaryHook</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
         </div>
         <p>Debug canary for verifying hook propagation</p>
       </div>
@@ -1810,7 +1811,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>CodeQualityPipeline</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
         </div>
         <p>3 hooks</p>
       </div>
@@ -1819,7 +1820,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>CodingStandards</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">7 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">7 hooks</span></div>
         </div>
         <p>TypeScript quality enforcement hooks</p>
       </div>
@@ -1828,7 +1829,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>CronStatusLine</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">5 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">5 hooks</span></div>
         </div>
         <p>Cron job scheduling and status line management</p>
       </div>
@@ -1837,7 +1838,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>DuplicationDetection</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span></div>
         </div>
         <p>Detect and prevent code duplication using SWC-based function analysis</p>
       </div>
@@ -1846,7 +1847,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>ExecutionEvidence</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
         </div>
         <p>Execution evidence verification from tool results</p>
       </div>
@@ -1855,7 +1856,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>GitSafety</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">7 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">7 hooks</span></div>
         </div>
         <p>Git safety, branch protection, and worktree verification</p>
       </div>
@@ -1864,7 +1865,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>IdentityBranding</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
         </div>
         <p>Maple identity branding and usage analytics</p>
       </div>
@@ -1873,7 +1874,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>KoordDaemon</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">6 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">6 hooks</span></div>
         </div>
         <p>Koord agent-to-agent daemon lifecycle hooks</p>
       </div>
@@ -1882,7 +1883,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>LastResponseCache</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
         </div>
         <p>Last response caching for reference</p>
       </div>
@@ -1891,7 +1892,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>LearningFeedback</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
         </div>
         <p>Learning signal capture and relationship memory</p>
       </div>
@@ -1900,7 +1901,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>ObligationStateMachines</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">9 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">9 hooks</span></div>
         </div>
         <p>Documentation, test, citation, and hook-doc obligations</p>
       </div>
@@ -1909,7 +1910,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>QuestionAnswered</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
         </div>
         <p>User question response tracking</p>
       </div>
@@ -1918,7 +1919,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>SecurityValidator</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">4 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">4 hooks</span></div>
         </div>
         <p>Protected file write prevention</p>
       </div>
@@ -1927,7 +1928,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>SessionFraming</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">4 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">4 hooks</span></div>
         </div>
         <p>Session initialization, context loading, and branch awareness</p>
       </div>
@@ -1936,7 +1937,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>SkillGuard</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
         </div>
         <p>Skill invocation validation</p>
       </div>
@@ -1945,7 +1946,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>SteeringRuleInjector</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
         </div>
         <p>Contextual steering rule injection based on event type and keyword matching</p>
       </div>
@@ -1954,7 +1955,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>StopOrchestrator</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
         </div>
         <p>Stop event coordination</p>
       </div>
@@ -1963,7 +1964,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>VoiceGate</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
         </div>
         <p>Voice notification routing control</p>
       </div>
@@ -1972,7 +1973,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>WikiPipeline</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
         </div>
         <p>Wiki knowledge pipeline: session ingestion, context injection, and read tracking</p>
       </div>
@@ -1981,7 +1982,7 @@ section[id] {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>WorkLifecycle</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">6 hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">6 hooks</span></div>
         </div>
         <p>Session work tracking, summaries, and content generation</p>
       </div>

--- a/scripts/docs/style.css
+++ b/scripts/docs/style.css
@@ -518,6 +518,7 @@ section > p {
 }
 
 .card-header h3 {
+  flex: 1;
   margin-bottom: 0;
   min-width: 0;
   overflow: hidden;

--- a/scripts/docs/style.css
+++ b/scripts/docs/style.css
@@ -530,8 +530,8 @@ section > p {
 .card-badges {
   display: flex;
   gap: 6px;
-  margin-left: auto;
   flex-shrink: 0;
+  flex-wrap: nowrap;
 }
 
 .card-badge {

--- a/scripts/docs/template.test.ts
+++ b/scripts/docs/template.test.ts
@@ -214,6 +214,84 @@ describe("renderHookPage", () => {
   });
 });
 
+// ─── Security: esc() single-quote escaping (E1) ──────────────────────────────
+
+describe("esc() single-quote safety", () => {
+  it("escapes single quotes in hook names used in onclick attributes", () => {
+    // A hook name containing a single quote must not break onclick='...' contexts
+    const group: GroupMeta = {
+      name: "O'Malley",
+      description: "Group with apostrophe in name",
+      hooks: [
+        {
+          name: "Hook'A",
+          group: "O'Malley",
+          event: "PreToolUse",
+          description: "Hook with apostrophe",
+          hasDoc: true,
+        },
+      ],
+    };
+    const html = renderGroupPage(group);
+    // Single quotes must be escaped as &#39; wherever they appear in onclick/href contexts
+    expect(html).not.toContain("Hook'A.html");
+    expect(html).toContain("Hook&#39;A.html");
+  });
+});
+
+// ─── Security: inlineMd() URL validation (E2) ────────────────────────────────
+
+describe("inlineMd() URL safety", () => {
+  it("rejects javascript: URLs", () => {
+    const html = markdownToHtml("[click](javascript:alert(1))");
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain('href="#"');
+  });
+
+  it("rejects javascript: URLs case-insensitively", () => {
+    const html = markdownToHtml("[click](JavaScript:alert(1))");
+    expect(html).not.toContain("JavaScript:");
+    expect(html).toContain('href="#"');
+  });
+
+  it("rejects data: URLs", () => {
+    const html = markdownToHtml("[click](data:text/html,<h1>xss</h1>)");
+    expect(html).not.toContain("data:");
+    expect(html).toContain('href="#"');
+  });
+
+  it("rejects vbscript: URLs", () => {
+    const html = markdownToHtml("[click](vbscript:msgbox(1))");
+    expect(html).not.toContain("vbscript:");
+    expect(html).toContain('href="#"');
+  });
+
+  it("allows https: URLs", () => {
+    const html = markdownToHtml("[click](https://example.com)");
+    expect(html).toContain('href="https://example.com"');
+  });
+
+  it("allows http: URLs", () => {
+    const html = markdownToHtml("[click](http://example.com)");
+    expect(html).toContain('href="http://example.com"');
+  });
+
+  it("allows relative URLs", () => {
+    const html = markdownToHtml("[click](./foo/bar.html)");
+    expect(html).toContain('href="./foo/bar.html"');
+  });
+
+  it("allows anchor URLs", () => {
+    const html = markdownToHtml("[click](#section)");
+    expect(html).toContain('href="#section"');
+  });
+
+  it("allows mailto: URLs", () => {
+    const html = markdownToHtml("[email](mailto:a@b.com)");
+    expect(html).toContain('href="mailto:a@b.com"');
+  });
+});
+
 // ─── renderGroupPage ─────────────────────────────────────────────────────────
 
 describe("renderGroupPage", () => {
@@ -251,6 +329,11 @@ describe("renderGroupPage", () => {
   it("includes summary grid", () => {
     const html = renderGroupPage(group);
     expect(html).toContain("summary-grid");
+  });
+
+  it("wraps event badges in card-badges container", () => {
+    const html = renderGroupPage(group);
+    expect(html).toContain('class="card-badges"');
   });
 });
 

--- a/scripts/docs/template.ts
+++ b/scripts/docs/template.ts
@@ -801,7 +801,7 @@ export function renderIndexPage(groups: GroupMeta[]): string {
         <div class="card-header">
           <div class="card-icon">&#x1F4C1;</div>
           <h3>${esc(g.name)}</h3>
-          <span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">${g.hooks.length} hooks</span>
+          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">${g.hooks.length} hooks</span></div>
         </div>
         <p>${esc(g.description || `${g.hooks.length} hooks`)}</p>
       </div>`,

--- a/scripts/docs/template.ts
+++ b/scripts/docs/template.ts
@@ -176,7 +176,8 @@ function esc(str: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 /** Escape for code blocks — only escape HTML-meaningful chars, preserve quotes. */
@@ -184,12 +185,26 @@ function escCode(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/** Safe URL allowlist — reject javascript:, data:, vbscript: and anything else not on the list. */
+function safeLinkUrl(url: string): string {
+  const trimmed = url.trim();
+  if (/^(javascript|data|vbscript):/i.test(trimmed)) return "#";
+  if (/^(https?:|mailto:|\/|#)/.test(trimmed)) return trimmed;
+  // Relative paths (no scheme) are fine
+  if (!/^[a-z][a-z0-9+\-.]*:/i.test(trimmed)) return trimmed;
+  // Unknown scheme — reject
+  return "#";
+}
+
 function inlineMd(text: string): string {
   return text
     .replace(/`([^`]+)`/g, "<code>$1</code>")
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
     .replace(/\*([^*]+)\*/g, "<em>$1</em>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+    .replace(
+      /\[([^\]]+)\]\(([^)]+)\)/g,
+      (_, linkText, url) => `<a href="${safeLinkUrl(url)}">${linkText}</a>`,
+    );
 }
 
 // ─── Block-level Markdown → HTML ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Wraps the bare `<span class="card-badge">` in a `<div class="card-badges">` container at `/tmp/pai-hooks-wt-113/scripts/docs/template.ts` line 804, so the badge participates in the existing flex layout
- Adds `flex: 1` to `.card-header h3` in `/tmp/pai-hooks-wt-113/scripts/docs/style.css` so the title expands and pushes the badge to the right edge

## Test plan

- [x] `bun test scripts/docs/template.test.ts` — 35 pass, 0 fail
- [x] `bun run scripts/docs/render.ts` — 24 groups, 77 hooks, 77 pages generated, 0 errors
- [ ] Visual check: index page group cards show badge right-aligned within card header

Closes #113

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple