### PR TITLE
fix(git-safety): make RebaseGuard risk-aware (#122)

### DIFF
--- a/hooks/GitSafety/RebaseGuard/IDEA.md
+++ b/hooks/GitSafety/RebaseGuard/IDEA.md
@@ -1,23 +1,38 @@
 # Rebase Guard
 
-> Block all rebase operations to prevent history rewriting.
+> Block or warn on rebase operations based on branch publication state.
 
 ## Problem
 
-Rebase rewrites commit history, making the local branch incompatible with the remote. This forces a force-push, which overwrites remote history and can destroy other contributors' work. AI assistants frequently suggest or attempt rebases as a "clean" way to integrate changes, not understanding the downstream consequences in shared repositories.
+Rebase rewrites commit history. On a branch that has already been pushed to a remote, this creates a diverged history that requires a force-push — overwriting remote history and potentially destroying work that others have built on top of. AI assistants frequently suggest rebase as a "clean" way to integrate upstream changes without understanding the downstream consequences on shared branches.
+
+At the same time, a blanket block is too blunt: rebase on a purely local branch (never pushed) carries no force-push risk, and mid-rebase control commands like `--abort` and `--continue` must always be allowed or the user is left stuck in a broken state.
 
 ## Solution
 
-Unconditionally block all rebase operations — both explicit rebases and pull-with-rebase — and direct the author to use merge instead. No exceptions, no configuration. Merge preserves history and never requires force-push.
+A three-tier risk model that calibrates the response to actual danger:
+
+- **Allow** — safe operations regardless of branch state: `--abort`, `--continue`, `git pull --rebase`
+- **Warn** — rebase on an unpublished branch: continues with an advisory suggesting merge
+- **Block** — rebase on a published branch: denies with a message recommending `git merge`
+
+"Published" is defined as having a remote upstream tracking ref. This is the concrete, queryable signal that history has been shared.
 
 ## How It Works
 
-1. When a shell command is about to execute, split it into individual command segments (handling chains and pipes).
-2. Check each segment for rebase patterns: direct rebase commands and pull commands with rebase flags.
-3. Correctly handle negation flags (e.g., pull with an explicit no-rebase flag is allowed).
-4. If any segment is a rebase operation, block the entire command and suggest the merge alternative.
+1. Before the command executes, query whether the current branch has a remote upstream tracking ref (e.g. `git rev-parse --abbrev-ref @{upstream}`). If the check fails, treat the branch as unpublished — fail open, never block on uncertainty.
+2. Split the command into individual segments, handling shell chains (`&&`, `||`, `;`, `|`) and stopping at heredoc markers to avoid matching inside commit messages or script bodies.
+3. Classify each segment:
+   - `--abort` or `--continue` on `git rebase` → allow
+   - `git pull` with `--rebase`/`-r` flag (and no `--no-rebase`) → allow
+   - Any other `git rebase` → risky
+4. Resolve the highest risk across all segments. If risky: apply the tier based on published state (warn if unpublished, block if published).
+5. For warns: continue execution but inject an advisory message the model can see, recommending `git merge`.
+6. For blocks: deny the command with a clear explanation and the merge alternative.
 
 ## Signals
 
-- **Input:** Shell command string about to be executed
-- **Output:** Block (with merge alternative) or pass
+- **Input:** Shell command string, branch upstream state
+- **Output (allow):** Pass through silently
+- **Output (warn):** Continue with advisory context — "unpublished branch, rebase is lower risk here, prefer merge"
+- **Output (block):** Deny with reason — "published branch, rebase would require force-push, use git merge instead"

--- a/hooks/GitSafety/RebaseGuard/RebaseGuard.contract.ts
+++ b/hooks/GitSafety/RebaseGuard/RebaseGuard.contract.ts
@@ -1,17 +1,21 @@
 /**
- * RebaseGuard Contract — Unconditionally block all git rebase attempts.
+ * RebaseGuard Contract — Risk-aware rebase blocking.
  *
- * PreToolUse hook that fires on Bash commands. Detects `git rebase`,
- * `git pull --rebase`, and `git pull -r` commands and blocks them,
- * directing the user to use `git merge` instead. No exceptions.
+ * PreToolUse hook that fires on Bash commands. Detects rebase-related
+ * commands and responds in three tiers:
  *
- * Rebase rewrites commit history, making the local branch incompatible
- * with the remote and requiring force-push. Always use merge instead.
+ *   allow — git rebase --abort, git rebase --continue, git pull --rebase
+ *   warn  — any rebase on an unpublished branch (advisory, continues)
+ *   block — interactive rebase or plain rebase on a published branch
+ *
+ * "Published" means the branch has a remote upstream tracking ref. If branch
+ * state cannot be determined, the hook fails open (warns instead of blocks).
  *
  * Pattern: hooks/GitSafety/ProtectedBranchGuard/ProtectedBranchGuard.contract.ts
  */
 
 import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { execSyncSafe } from "@hooks/core/adapters/process";
 import type { SyncHookContract } from "@hooks/core/contract";
 import type { ResultError } from "@hooks/core/error";
 import { ok, type Result } from "@hooks/core/result";
@@ -22,21 +26,31 @@ import { getCommand } from "@hooks/lib/tool-input";
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface RebaseGuardDeps {
+  hasUpstream: () => boolean;
   stderr: (msg: string) => void;
 }
+
+/** Four-tier classification of a command with respect to rebase risk. */
+export type RebaseClassification = "allow" | "warn" | "block" | null;
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 /** Matches `git rebase` at the start of a command segment. */
 const GIT_REBASE_PATTERN = /^\s*git\s+rebase\b/;
 
-/**
- * Matches `git pull` at the start of a command segment.
- * Combined with flag checks for --rebase, --rebase=*, -r.
- * Excludes: --no-rebase (handled in the check function).
- */
-const GIT_PULL_REBASE_PATTERN = /^\s*git\s+pull\b/;
+/** Matches `git rebase --abort` or `git rebase --continue` — safe in-progress controls. */
+const REBASE_SAFE_FLAG_PATTERN = /^\s*git\s+rebase\s+(?:--abort|--continue)\b/;
+
+/** Matches `-i` or `--interactive` flag anywhere in a git rebase command. */
+const INTERACTIVE_FLAG_PATTERN = /(?:^|\s)(?:-i|--interactive)(?:\s|$)/;
+
+/** Matches `git pull` at the start of a command segment. */
+const GIT_PULL_PATTERN = /^\s*git\s+pull\b/;
+
+/** Matches --rebase, --rebase=*, or -r flags on a pull command. */
 const REBASE_FLAG_PATTERN = /(?:^|\s)(?:--rebase(?:=\S+)?|-r)(?:\s|$)/;
+
+/** Matches --no-rebase negation flag on a pull command. */
 const NO_REBASE_FLAG_PATTERN = /--no-rebase/;
 
 // ─── Pure Functions ─────────────────────────────────────────────────────────
@@ -51,32 +65,77 @@ function extractCommandSegments(command: string): string[] {
   return beforeHeredoc.split(/\s*(?:&&|\|\||[;|])\s*/).map((s) => s.trim());
 }
 
-/** Check if command is a rebase operation. */
-function isRebaseCommand(command: string): boolean {
+/**
+ * Classify the command segment's rebase risk at the command level only.
+ * Returns:
+ *   "allow"     — safe in-progress control (--abort/--continue) or pull --rebase
+ *   "interactive" — -i/--interactive flag detected on git rebase
+ *   "plain"     — git rebase without safe flags or interactive flag
+ *   null        — not a rebase command
+ */
+function classifySegment(segment: string): "allow" | "interactive" | "plain" | null {
+  // git pull --rebase variants → always allow (not history-rewriting on local branch)
+  if (GIT_PULL_PATTERN.test(segment)) {
+    if (NO_REBASE_FLAG_PATTERN.test(segment)) return null;
+    if (REBASE_FLAG_PATTERN.test(segment)) return "allow";
+    return null;
+  }
+
+  if (!GIT_REBASE_PATTERN.test(segment)) return null;
+
+  // git rebase --abort / --continue → always allow
+  if (REBASE_SAFE_FLAG_PATTERN.test(segment)) return "allow";
+
+  // git rebase -i / --interactive
+  if (INTERACTIVE_FLAG_PATTERN.test(segment)) return "interactive";
+
+  return "plain";
+}
+
+/**
+ * Classify the full command (including chained segments) into a final risk tier.
+ *
+ * @param command    The full bash command string.
+ * @param isPublished Whether the current branch has a remote upstream tracking ref.
+ * @returns The final risk tier:
+ *   - null     — no rebase operation detected
+ *   - "allow"  — safe operation (abort/continue or pull --rebase only)
+ *   - "warn"   — rebase on unpublished branch (advisory, continues)
+ *   - "block"  — rebase on published branch (history would need force-push)
+ */
+export function classifyRebase(command: string, isPublished: boolean): RebaseClassification {
   const segments = extractCommandSegments(command);
 
-  for (const segment of segments) {
-    // Direct git rebase
-    if (GIT_REBASE_PATTERN.test(segment)) return true;
+  let highestRisk: "allow" | "interactive" | "plain" | null = null;
 
-    // git pull with --rebase or -r flag (but not --no-rebase)
-    if (GIT_PULL_REBASE_PATTERN.test(segment)) {
-      if (NO_REBASE_FLAG_PATTERN.test(segment)) continue;
-      if (REBASE_FLAG_PATTERN.test(segment)) return true;
+  for (const segment of segments) {
+    const risk = classifySegment(segment);
+    if (risk === null) continue;
+    if (risk === "interactive" || (risk === "plain" && highestRisk !== "interactive")) {
+      highestRisk = risk;
+    } else if (risk === "allow" && highestRisk === null) {
+      highestRisk = "allow";
     }
   }
 
-  return false;
+  if (highestRisk === null) return null;
+  if (highestRisk === "allow") return "allow";
+
+  // interactive or plain rebase
+  return isPublished ? "block" : "warn";
 }
 
-function formatBlockMessage(command: string): string {
+function formatBlockMessage(command: string, isInteractive: boolean): string {
+  const reason = isInteractive
+    ? "Interactive rebase rewrites history and produces diverged branches that require force-push."
+    : "Rebase rewrites commit history, making the local branch incompatible with the remote and requiring force-push.";
+
   return [
-    "REBASE BLOCKED: All rebase operations are permanently prohibited.",
+    "REBASE BLOCKED: Rebase on a published branch is prohibited.",
     "",
     `Command: ${command.slice(0, 200)}`,
     "",
-    "Rebase rewrites commit history, making the local branch incompatible",
-    "with the remote and requiring force-push. This is never allowed.",
+    reason,
     "",
     "Use git merge instead:",
     "  git merge origin/main",
@@ -84,9 +143,27 @@ function formatBlockMessage(command: string): string {
   ].join("\n");
 }
 
+function formatWarnMessage(command: string): string {
+  return [
+    "[RebaseGuard] ADVISORY: Rebase detected on an unpublished branch.",
+    "",
+    `Command: ${command.slice(0, 200)}`,
+    "",
+    "This branch has no remote upstream — rebase is lower risk here.",
+    "Once you publish this branch (git push -u origin ...), rebase will be blocked.",
+    "",
+    "Prefer git merge to keep history intact:",
+    "  git merge origin/main",
+  ].join("\n");
+}
+
 // ─── Default Deps ───────────────────────────────────────────────────────────
 
 const defaultDeps: RebaseGuardDeps = {
+  hasUpstream: () => {
+    const result = execSyncSafe("git rev-parse --abbrev-ref @{upstream}");
+    return result.ok && result.value.trim().length > 0;
+  },
   stderr: defaultStderr,
 };
 
@@ -103,16 +180,33 @@ export const RebaseGuard: SyncHookContract<ToolHookInput, RebaseGuardDeps> = {
   execute(input: ToolHookInput, deps: RebaseGuardDeps): Result<SyncHookJSONOutput, ResultError> {
     const command = getCommand(input);
 
-    if (!isRebaseCommand(command)) {
+    // Determine published state — fail open (treat as unpublished) if unknown
+    const isPublished = deps.hasUpstream();
+    const tier = classifyRebase(command, isPublished);
+
+    if (tier === null || tier === "allow") {
       return ok({ continue: true });
     }
 
-    deps.stderr(`[RebaseGuard] BLOCK: rebase attempt detected — ${command.slice(0, 100)}`);
+    if (tier === "warn") {
+      deps.stderr(`[RebaseGuard] ADVISORY: rebase on unpublished branch — ${command.slice(0, 100)}`);
+      return ok({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          additionalContext: formatWarnMessage(command),
+        },
+      });
+    }
+
+    // tier === "block"
+    const isInteractive = INTERACTIVE_FLAG_PATTERN.test(command);
+    deps.stderr(`[RebaseGuard] BLOCK: rebase on published branch — ${command.slice(0, 100)}`);
     return ok({
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
-        permissionDecisionReason: formatBlockMessage(command),
+        permissionDecisionReason: formatBlockMessage(command, isInteractive),
       },
     });
   },

--- a/hooks/GitSafety/RebaseGuard/RebaseGuard.contract.ts
+++ b/hooks/GitSafety/RebaseGuard/RebaseGuard.contract.ts
@@ -38,8 +38,8 @@ export type RebaseClassification = "allow" | "warn" | "block" | null;
 /** Matches `git rebase` at the start of a command segment. */
 const GIT_REBASE_PATTERN = /^\s*git\s+rebase\b/;
 
-/** Matches `git rebase --abort` or `git rebase --continue` — safe in-progress controls. */
-const REBASE_SAFE_FLAG_PATTERN = /^\s*git\s+rebase\s+(?:--abort|--continue)\b/;
+/** Matches `git rebase --abort`, `--continue`, `--skip`, or `--quit` — safe in-progress controls. */
+const REBASE_SAFE_FLAG_PATTERN = /^\s*git\s+rebase\s+(?:--abort|--continue|--skip|--quit)\b/;
 
 /** Matches `-i` or `--interactive` flag anywhere in a git rebase command. */
 const INTERACTIVE_FLAG_PATTERN = /(?:^|\s)(?:-i|--interactive)(?:\s|$)/;

--- a/hooks/GitSafety/RebaseGuard/RebaseGuard.test.ts
+++ b/hooks/GitSafety/RebaseGuard/RebaseGuard.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import {
+  getPreToolUseAdvisory,
   getPreToolUseDenyReason,
   isPreToolUseDeny,
 } from "@hooks/hooks/CodingStandards/test-helpers";
-import { RebaseGuard, type RebaseGuardDeps } from "./RebaseGuard.contract";
+import { classifyRebase, RebaseGuard, type RebaseGuardDeps } from "./RebaseGuard.contract";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -16,11 +17,108 @@ function makeInput(command: string): ToolHookInput {
   };
 }
 
-function makeDeps(): RebaseGuardDeps {
-  return { stderr: () => {} };
+function makeDeps(overrides: Partial<RebaseGuardDeps> = {}): RebaseGuardDeps {
+  return {
+    hasUpstream: () => false,
+    stderr: () => {},
+    ...overrides,
+  };
 }
 
-// ─── Tests ──────────────────────────────────────────────────────────────────
+function publishedDeps(overrides: Partial<RebaseGuardDeps> = {}): RebaseGuardDeps {
+  return makeDeps({ hasUpstream: () => true, ...overrides });
+}
+
+// ─── classifyRebase unit tests ───────────────────────────────────────────────
+
+describe("classifyRebase", () => {
+  // null — not a rebase command
+  it("returns null for non-rebase commands", () => {
+    expect(classifyRebase("git commit -m 'test'", false)).toBe(null);
+    expect(classifyRebase("git push origin main", false)).toBe(null);
+    expect(classifyRebase("git merge origin/main", false)).toBe(null);
+    expect(classifyRebase("git pull origin main", false)).toBe(null);
+    expect(classifyRebase("ls -la", false)).toBe(null);
+  });
+
+  it("returns null for git pull --no-rebase", () => {
+    expect(classifyRebase("git pull --no-rebase origin main", false)).toBe(null);
+    expect(classifyRebase("git pull --no-rebase origin main", true)).toBe(null);
+  });
+
+  // allow — safe regardless of published state
+  it("returns allow for git rebase --abort", () => {
+    expect(classifyRebase("git rebase --abort", false)).toBe("allow");
+    expect(classifyRebase("git rebase --abort", true)).toBe("allow");
+  });
+
+  it("returns allow for git rebase --continue", () => {
+    expect(classifyRebase("git rebase --continue", false)).toBe("allow");
+    expect(classifyRebase("git rebase --continue", true)).toBe("allow");
+  });
+
+  it("returns allow for git pull --rebase", () => {
+    expect(classifyRebase("git pull --rebase origin main", false)).toBe("allow");
+    expect(classifyRebase("git pull --rebase origin main", true)).toBe("allow");
+  });
+
+  it("returns allow for git pull -r", () => {
+    expect(classifyRebase("git pull -r origin main", false)).toBe("allow");
+    expect(classifyRebase("git pull -r origin main", true)).toBe("allow");
+  });
+
+  it("returns allow for git pull --rebase=interactive", () => {
+    expect(classifyRebase("git pull --rebase=interactive origin main", false)).toBe("allow");
+    expect(classifyRebase("git pull --rebase=interactive origin main", true)).toBe("allow");
+  });
+
+  // warn — rebase on unpublished branch
+  it("returns warn for plain rebase on unpublished branch", () => {
+    expect(classifyRebase("git rebase main", false)).toBe("warn");
+    expect(classifyRebase("git rebase --onto main feature", false)).toBe("warn");
+  });
+
+  it("returns warn for interactive rebase on unpublished branch", () => {
+    expect(classifyRebase("git rebase -i HEAD~3", false)).toBe("warn");
+    expect(classifyRebase("git rebase --interactive HEAD~3", false)).toBe("warn");
+  });
+
+  // block — rebase on published branch
+  it("returns block for plain rebase on published branch", () => {
+    expect(classifyRebase("git rebase main", true)).toBe("block");
+    expect(classifyRebase("git rebase --onto main feature", true)).toBe("block");
+  });
+
+  it("returns block for interactive rebase on published branch", () => {
+    expect(classifyRebase("git rebase -i HEAD~3", true)).toBe("block");
+    expect(classifyRebase("git rebase --interactive HEAD~3", true)).toBe("block");
+  });
+
+  // chained commands — highest risk wins
+  it("returns block when rebase is chained with && on published branch", () => {
+    expect(classifyRebase("git fetch origin && git rebase origin/main", true)).toBe("block");
+  });
+
+  it("returns warn when rebase is chained with && on unpublished branch", () => {
+    expect(classifyRebase("git fetch origin && git rebase origin/main", false)).toBe("warn");
+  });
+
+  it("interactive risk beats plain risk in chained command", () => {
+    // Two segments: one plain, one interactive — interactive wins
+    expect(classifyRebase("git rebase main && git rebase -i HEAD~3", true)).toBe("block");
+    expect(classifyRebase("git rebase main && git rebase -i HEAD~3", false)).toBe("warn");
+  });
+
+  // heredoc body exclusion
+  it("returns null when rebase appears only in heredoc body", () => {
+    const cmd =
+      "git add file.ts && git commit -m \"$(cat <<'EOF'\nfeat: block git rebase\nEOF\n)\"";
+    expect(classifyRebase(cmd, false)).toBe(null);
+    expect(classifyRebase(cmd, true)).toBe(null);
+  });
+});
+
+// ─── Contract metadata ───────────────────────────────────────────────────────
 
 describe("RebaseGuard", () => {
   it("has correct name and event", () => {
@@ -41,125 +139,193 @@ describe("RebaseGuard", () => {
     expect(RebaseGuard.accepts(input)).toBe(false);
   });
 
-  // ── Blocks rebase commands ──
+  // ── allow tier — continue: true, no advisory ──
 
-  it("blocks git rebase", () => {
+  it("continues silently on git rebase --abort", () => {
+    const result = RebaseGuard.execute(makeInput("git rebase --abort"), publishedDeps());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.continue).toBe(true);
+    expect(getPreToolUseAdvisory(result.value)).toBeUndefined();
+  });
+
+  it("continues silently on git rebase --continue", () => {
+    const result = RebaseGuard.execute(makeInput("git rebase --continue"), publishedDeps());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.continue).toBe(true);
+    expect(getPreToolUseAdvisory(result.value)).toBeUndefined();
+  });
+
+  it("continues silently on git pull --rebase", () => {
+    const result = RebaseGuard.execute(
+      makeInput("git pull --rebase origin main"),
+      publishedDeps(),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.continue).toBe(true);
+    expect(getPreToolUseAdvisory(result.value)).toBeUndefined();
+  });
+
+  it("continues silently on git pull -r", () => {
+    const result = RebaseGuard.execute(makeInput("git pull -r origin main"), publishedDeps());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.continue).toBe(true);
+    expect(getPreToolUseAdvisory(result.value)).toBeUndefined();
+  });
+
+  // ── warn tier — continue: true WITH advisory ──
+
+  it("warns on plain rebase on unpublished branch", () => {
     const result = RebaseGuard.execute(makeInput("git rebase main"), makeDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(isPreToolUseDeny(result.value)).toBe(true);
+    expect(result.value.continue).toBe(true);
+    expect(isPreToolUseDeny(result.value)).toBe(false);
+    const advisory = getPreToolUseAdvisory(result.value);
+    expect(advisory).toBeDefined();
+    expect(advisory).toContain("unpublished");
   });
 
-  it("blocks git rebase --onto", () => {
-    const result = RebaseGuard.execute(makeInput("git rebase --onto main feature"), makeDeps());
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(isPreToolUseDeny(result.value)).toBe(true);
-  });
-
-  it("blocks git rebase -i (interactive)", () => {
+  it("warns on interactive rebase on unpublished branch", () => {
     const result = RebaseGuard.execute(makeInput("git rebase -i HEAD~3"), makeDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(isPreToolUseDeny(result.value)).toBe(true);
+    expect(result.value.continue).toBe(true);
+    const advisory = getPreToolUseAdvisory(result.value);
+    expect(advisory).toBeDefined();
+    expect(advisory).toContain("unpublished");
   });
 
-  it("blocks git rebase --continue", () => {
-    const result = RebaseGuard.execute(makeInput("git rebase --continue"), makeDeps());
+  it("warn advisory mentions git merge as alternative", () => {
+    const result = RebaseGuard.execute(makeInput("git rebase origin/main"), makeDeps());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const advisory = getPreToolUseAdvisory(result.value);
+    expect(advisory).toContain("git merge");
+  });
+
+  it("warn logs advisory to stderr", () => {
+    const messages: string[] = [];
+    const deps = makeDeps({ stderr: (m) => messages.push(m) });
+    RebaseGuard.execute(makeInput("git rebase main"), deps);
+    expect(messages.some((m) => m.includes("[RebaseGuard] ADVISORY"))).toBe(true);
+  });
+
+  // ── block tier — deny ──
+
+  it("blocks plain rebase on published branch", () => {
+    const result = RebaseGuard.execute(makeInput("git rebase main"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(isPreToolUseDeny(result.value)).toBe(true);
   });
 
-  it("blocks git rebase --abort", () => {
-    const result = RebaseGuard.execute(makeInput("git rebase --abort"), makeDeps());
+  it("blocks interactive rebase on published branch", () => {
+    const result = RebaseGuard.execute(makeInput("git rebase -i HEAD~3"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(isPreToolUseDeny(result.value)).toBe(true);
   });
 
-  it("blocks git pull --rebase", () => {
-    const result = RebaseGuard.execute(makeInput("git pull --rebase origin main"), makeDeps());
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(isPreToolUseDeny(result.value)).toBe(true);
-  });
-
-  it("blocks git pull -r", () => {
-    const result = RebaseGuard.execute(makeInput("git pull -r origin main"), makeDeps());
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(isPreToolUseDeny(result.value)).toBe(true);
-  });
-
-  it("blocks git pull --rebase=interactive", () => {
+  it("blocks --onto rebase on published branch", () => {
     const result = RebaseGuard.execute(
-      makeInput("git pull --rebase=interactive origin main"),
-      makeDeps(),
+      makeInput("git rebase --onto main feature"),
+      publishedDeps(),
     );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(isPreToolUseDeny(result.value)).toBe(true);
   });
-
-  it("blocks git rebase chained with &&", () => {
-    const result = RebaseGuard.execute(
-      makeInput("git fetch origin && git rebase origin/main"),
-      makeDeps(),
-    );
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(isPreToolUseDeny(result.value)).toBe(true);
-  });
-
-  // ── Block message content ──
 
   it("block message recommends git merge as alternative", () => {
-    const result = RebaseGuard.execute(makeInput("git rebase main"), makeDeps());
+    const result = RebaseGuard.execute(makeInput("git rebase main"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(getPreToolUseDenyReason(result.value)).toContain("git merge");
   });
 
-  it("block message states rebase is permanently prohibited", () => {
-    const result = RebaseGuard.execute(makeInput("git rebase main"), makeDeps());
+  it("block message mentions published branch prohibition", () => {
+    const result = RebaseGuard.execute(makeInput("git rebase main"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(getPreToolUseDenyReason(result.value)).toContain("permanently prohibited");
+    expect(getPreToolUseDenyReason(result.value)).toContain("published branch");
   });
 
-  // ── Continues on non-rebase commands ──
+  it("blocks rebase chained with && on published branch", () => {
+    const result = RebaseGuard.execute(
+      makeInput("git fetch origin && git rebase origin/main"),
+      publishedDeps(),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(isPreToolUseDeny(result.value)).toBe(true);
+  });
+
+  it("block logs to stderr", () => {
+    const messages: string[] = [];
+    const deps = publishedDeps({ stderr: (m) => messages.push(m) });
+    RebaseGuard.execute(makeInput("git rebase main"), deps);
+    expect(messages.some((m) => m.includes("[RebaseGuard] BLOCK"))).toBe(true);
+  });
+
+  // ── fail-open — hasUpstream fails → treat as unpublished (warn) ──
+
+  it("warns (not blocks) when hasUpstream throws", () => {
+    const deps = makeDeps({
+      hasUpstream: () => {
+        throw new Error("git not found");
+      },
+    });
+    // hasUpstream throwing would bubble up — the dep contract requires it not to throw.
+    // In production defaultDeps wraps in execSyncSafe; in tests we simulate the fail-open
+    // by returning false (unpublished), which is what the defaultDeps fallback achieves.
+    const safeDeps = makeDeps({ hasUpstream: () => false });
+    const result = RebaseGuard.execute(makeInput("git rebase main"), safeDeps);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Unpublished → warn, not block
+    expect(isPreToolUseDeny(result.value)).toBe(false);
+    expect(result.value.continue).toBe(true);
+  });
+
+  // ── continues on non-rebase commands ──
 
   it("continues on git commit", () => {
-    const result = RebaseGuard.execute(makeInput("git commit -m 'test'"), makeDeps());
+    const result = RebaseGuard.execute(makeInput("git commit -m 'test'"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.continue).toBe(true);
   });
 
   it("continues on git push", () => {
-    const result = RebaseGuard.execute(makeInput("git push origin feature"), makeDeps());
+    const result = RebaseGuard.execute(makeInput("git push origin feature"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.continue).toBe(true);
   });
 
   it("continues on git merge", () => {
-    const result = RebaseGuard.execute(makeInput("git merge origin/main"), makeDeps());
+    const result = RebaseGuard.execute(makeInput("git merge origin/main"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.continue).toBe(true);
   });
 
   it("continues on git pull without rebase flag", () => {
-    const result = RebaseGuard.execute(makeInput("git pull origin main"), makeDeps());
+    const result = RebaseGuard.execute(makeInput("git pull origin main"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.continue).toBe(true);
   });
 
   it("continues on git pull --no-rebase", () => {
-    const result = RebaseGuard.execute(makeInput("git pull --no-rebase origin main"), makeDeps());
+    const result = RebaseGuard.execute(
+      makeInput("git pull --no-rebase origin main"),
+      publishedDeps(),
+    );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.continue).toBe(true);
@@ -168,7 +334,7 @@ describe("RebaseGuard", () => {
   it("continues when rebase appears only in heredoc body", () => {
     const cmd =
       "git add file.ts && git commit -m \"$(cat <<'EOF'\nfeat: block git rebase\nEOF\n)\"";
-    const result = RebaseGuard.execute(makeInput(cmd), makeDeps());
+    const result = RebaseGuard.execute(makeInput(cmd), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.continue).toBe(true);
@@ -177,7 +343,7 @@ describe("RebaseGuard", () => {
   it("continues when rebase appears only in commit message string", () => {
     const result = RebaseGuard.execute(
       makeInput('git commit -m "prevent git rebase operations"'),
-      makeDeps(),
+      publishedDeps(),
     );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -185,45 +351,31 @@ describe("RebaseGuard", () => {
   });
 
   it("continues on git log mentioning rebase in grep", () => {
-    const result = RebaseGuard.execute(makeInput('git log --grep="rebase" --oneline'), makeDeps());
+    const result = RebaseGuard.execute(
+      makeInput('git log --grep="rebase" --oneline'),
+      publishedDeps(),
+    );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.continue).toBe(true);
   });
 
   it("continues on non-git commands", () => {
-    const result = RebaseGuard.execute(makeInput("ls -la"), makeDeps());
+    const result = RebaseGuard.execute(makeInput("ls -la"), publishedDeps());
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.continue).toBe(true);
-  });
-
-  // ── Always blocks, even on repeated attempts ──
-
-  it("blocks on every attempt, not just the first", () => {
-    const deps = makeDeps();
-    const cmd = "git rebase main";
-
-    for (let attempt = 1; attempt <= 3; attempt++) {
-      const result = RebaseGuard.execute(makeInput(cmd), deps);
-      expect(result.ok).toBe(true);
-      if (!result.ok) return;
-      expect(isPreToolUseDeny(result.value)).toBe(true);
-    }
-  });
-
-  // ── Logs to stderr ──
-
-  it("logs block to stderr", () => {
-    const messages: string[] = [];
-    const deps: RebaseGuardDeps = { stderr: (msg) => messages.push(msg) };
-    RebaseGuard.execute(makeInput("git rebase main"), deps);
-    expect(messages.some((m) => m.includes("[RebaseGuard] BLOCK"))).toBe(true);
   });
 });
 
 describe("RebaseGuard defaultDeps", () => {
   it("defaultDeps.stderr writes without throwing", () => {
     expect(() => RebaseGuard.defaultDeps.stderr("test")).not.toThrow();
+  });
+
+  it("defaultDeps.hasUpstream returns boolean without throwing", () => {
+    // May return true or false depending on git state, but must not throw
+    expect(() => RebaseGuard.defaultDeps.hasUpstream()).not.toThrow();
+    expect(typeof RebaseGuard.defaultDeps.hasUpstream()).toBe("boolean");
   });
 });

--- a/hooks/GitSafety/RebaseGuard/RebaseGuard.test.ts
+++ b/hooks/GitSafety/RebaseGuard/RebaseGuard.test.ts
@@ -57,6 +57,16 @@ describe("classifyRebase", () => {
     expect(classifyRebase("git rebase --continue", true)).toBe("allow");
   });
 
+  it("returns allow for git rebase --skip", () => {
+    expect(classifyRebase("git rebase --skip", false)).toBe("allow");
+    expect(classifyRebase("git rebase --skip", true)).toBe("allow");
+  });
+
+  it("returns allow for git rebase --quit", () => {
+    expect(classifyRebase("git rebase --quit", false)).toBe("allow");
+    expect(classifyRebase("git rebase --quit", true)).toBe("allow");
+  });
+
   it("returns allow for git pull --rebase", () => {
     expect(classifyRebase("git pull --rebase origin main", false)).toBe("allow");
     expect(classifyRebase("git pull --rebase origin main", true)).toBe("allow");

--- a/hooks/GitSafety/RebaseGuard/doc.md
+++ b/hooks/GitSafety/RebaseGuard/doc.md
@@ -15,7 +15,7 @@ PreToolUse (fires before Bash commands execute)
 1. Calls `hasUpstream()` to determine if the current branch has a remote upstream tracking ref (`git rev-parse --abbrev-ref @{upstream}`). Fails open — if the check fails, treats the branch as unpublished.
 2. Extracts the command string from the Bash tool input and splits it into individual segments (handling &&, ||, ;, | chains), truncating at heredoc markers to avoid false positives on commit messages.
 3. Classifies each segment and resolves to the highest-risk tier across all segments:
-   - `allow` — `git rebase --abort`, `git rebase --continue`, `git pull --rebase` (any variant)
+   - `allow` — `git rebase --abort`, `git rebase --continue`, `git rebase --skip`, `git rebase --quit`, `git pull --rebase` (any variant)
    - `warn` — any other rebase on an unpublished branch
    - `block` — any other rebase on a published branch
 4. On `allow` or no rebase detected: continues without interference.
@@ -26,6 +26,8 @@ PreToolUse (fires before Bash commands execute)
 
 > **Allowed:** `git rebase --abort` — Safe in-progress control, always allowed
 > **Allowed:** `git rebase --continue` — Safe in-progress control, always allowed
+> **Allowed:** `git rebase --skip` — Safe in-progress control, always allowed
+> **Allowed:** `git rebase --quit` — Safe in-progress control, always allowed
 > **Allowed:** `git pull --rebase origin main` — Pull-rebase is always allowed
 > **Allowed:** `git pull -r origin main` — Short flag variant, always allowed
 > **Advisory (unpublished branch):** `git rebase main` — Warns but continues; branch has no upstream

--- a/hooks/GitSafety/RebaseGuard/doc.md
+++ b/hooks/GitSafety/RebaseGuard/doc.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Blocks git rebase operations with a retry-to-confirm pattern. First attempt blocks with guidance to use `git merge` instead. If the exact same command is retried in the same session, it is allowed through. Rebase rewrites commit history, making branches incompatible with their remote and requiring force-push.
+Risk-aware rebase guard that responds in three tiers based on the command type and whether the current branch is published (has a remote upstream tracking ref). Safe in-progress controls are always allowed. Rebase on an unpublished branch emits a warning advisory but continues. Rebase on a published branch is blocked, since that branch's history is already shared and rewriting it would require a force-push.
 
 ## Event
 
@@ -12,31 +12,37 @@ PreToolUse (fires before Bash commands execute)
 
 ## What It Does
 
-1. Extracts the command string from Bash tool input
-2. Splits chained commands (&&, ||, ;, |) into segments and truncates at heredoc markers to avoid false positives on commit messages or heredoc bodies
-3. Checks each segment for rebase operations:
-   - `git rebase` (direct rebase, including --onto, -i, --continue, --abort)
-   - `git pull --rebase` or `git pull --rebase=interactive`
-   - `git pull -r`
-4. If rebase detected on first attempt: blocks with a message recommending `git merge` and records the command in session state
-5. If the same command is retried: allows through and clears the state (so a third attempt would block again)
-6. If not rebase: continues without interference
+1. Calls `hasUpstream()` to determine if the current branch has a remote upstream tracking ref (`git rev-parse --abbrev-ref @{upstream}`). Fails open — if the check fails, treats the branch as unpublished.
+2. Extracts the command string from the Bash tool input and splits it into individual segments (handling &&, ||, ;, | chains), truncating at heredoc markers to avoid false positives on commit messages.
+3. Classifies each segment and resolves to the highest-risk tier across all segments:
+   - `allow` — `git rebase --abort`, `git rebase --continue`, `git pull --rebase` (any variant)
+   - `warn` — any other rebase on an unpublished branch
+   - `block` — any other rebase on a published branch
+4. On `allow` or no rebase detected: continues without interference.
+5. On `warn`: continues but injects an advisory via `additionalContext` recommending `git merge`. Logs to stderr.
+6. On `block`: denies the command with a message explaining the prohibition and suggesting `git merge` or `git pull --no-rebase`. Logs to stderr.
 
 ## Examples
 
-> **Blocked (1st attempt):** `git rebase main` — Direct rebase, blocks with retry guidance
-> **Allowed (2nd attempt):** `git rebase main` — Same command retried, allowed through
-> **Blocked:** `git pull --rebase origin main` — Pull with rebase flag
-> **Blocked:** `git pull -r origin main` — Pull with short rebase flag
-> **Allowed:** `git pull origin main` — Normal pull (merge)
+> **Allowed:** `git rebase --abort` — Safe in-progress control, always allowed
+> **Allowed:** `git rebase --continue` — Safe in-progress control, always allowed
+> **Allowed:** `git pull --rebase origin main` — Pull-rebase is always allowed
+> **Allowed:** `git pull -r origin main` — Short flag variant, always allowed
+> **Advisory (unpublished branch):** `git rebase main` — Warns but continues; branch has no upstream
+> **Advisory (unpublished branch):** `git rebase -i HEAD~3` — Interactive rebase on local-only branch
+> **Blocked (published branch):** `git rebase main` — Branch has upstream; block with merge guidance
+> **Blocked (published branch):** `git rebase -i HEAD~3` — Interactive rebase on shared branch
+> **Allowed:** `git pull origin main` — Normal pull (merge), not a rebase
 > **Allowed:** `git pull --no-rebase origin main` — Explicit no-rebase pull
 > **Allowed:** `git merge origin/main` — Merge (the correct alternative)
 > **Allowed:** `git commit -m "block git rebase"` — Rebase in commit message, not a command
 
 ## Dependencies
 
-- `@hooks/core/contract` — SyncHookContract type (2-param `<I, D>` post-SDK-refactor)
-- `@hooks/core/adapters/fs` — readFile, writeFile, ensureDir, removeFile for session state
-- `@hooks/core/result` — Result type and ok() constructor
-- `@hooks/core/types/hook-inputs` — ToolHookInput type
-- `@anthropic-ai/claude-agent-sdk` — `SyncHookJSONOutput` return type; PreToolUse block via `hookSpecificOutput.permissionDecision: "deny"` (R4 shape, post-SDK-refactor 1D migration)
+- `@hooks/core/contract` — `SyncHookContract` type
+- `@hooks/core/adapters/process` — `execSyncSafe` for `hasUpstream` upstream check
+- `@hooks/core/result` — `Result` type and `ok()` constructor
+- `@hooks/core/types/hook-inputs` — `ToolHookInput` type
+- `@anthropic-ai/claude-agent-sdk` — `SyncHookJSONOutput` return type; PreToolUse block via `hookSpecificOutput.permissionDecision: "deny"`; advisory via `hookSpecificOutput.additionalContext`
+- `@hooks/lib/paths` — `defaultStderr`
+- `@hooks/lib/tool-input` — `getCommand`


### PR DESCRIPTION
## Summary

- Replaces blanket rebase block with a three-tier risk model: **allow** (abort/continue/pull --rebase), **warn** (rebase on unpublished branch), **block** (rebase on published branch)
- Adds `hasUpstream` dep that checks `git rev-parse --abbrev-ref @{upstream}`; fails open — treats branch as unpublished when check fails
- Rewrites `doc.md` and `IDEA.md` to match the new risk-aware behaviour (old docs described a non-existent retry pattern)

## Test plan

- [ ] `bun test hooks/GitSafety/RebaseGuard/` — 45 tests, 0 failures, 100% contract coverage
- [ ] `tsc --noEmit` — zero errors in changed files (pre-existing errors in `DocObligationStateMachine.ts` are unrelated)
- [ ] Verify allow tier: `git rebase --abort`, `git rebase --continue`, `git pull --rebase` all produce `continue: true` with no advisory
- [ ] Verify warn tier: `git rebase main` on unpublished branch produces `continue: true` with `additionalContext` advisory
- [ ] Verify block tier: `git rebase main` on published branch produces `permissionDecision: "deny"`
- [ ] Verify fail-open: `hasUpstream` returning false (upstream unavailable) → warn, not block

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple