### PR TITLE
feat(session): add progressive session renaming hook (#93)

### DIFF
--- a/docs/groups/SessionFraming/SessionAutoRename.html
+++ b/docs/groups/SessionFraming/SessionAutoRename.html
@@ -1812,7 +1812,7 @@ A stateful hook that fires on every user prompt, accumulates keyword frequency a
 1. On each user prompt submission the hook reads the per-session state file (or creates a fresh one).
 2. Keywords are extracted from the prompt: lowercased, punctuation stripped, stop words and tokens under 4 characters removed.
 3. New keywords are merged into a cumulative frequency map stored in state.
-4. Three early-exit guards are checked in order: hook disabled, session has a custom name set by the user, rename interval has not elapsed since last rename.
+4. Three early-exit guards are checked in order: hook disabled, session has a custom name set by the user (`customName` flag in state — not yet automatically detected; must be set externally), rename interval has not elapsed since last rename.
 5. If none of the guards fire, the top-5 keywords by frequency are joined into a candidate title.
 6. The title is returned as `sessionTitle` in the hook output so the host application can apply it immediately.
 7. The new title is appended to a `titleHistory` list. If the last N titles are identical the session is marked `converged` and no further renames are issued.
@@ -1831,7 +1831,7 @@ Output:
 
 ## Context
 
-The first-prompt rename gives an immediate title from minimal signal. Subsequent renames (rate-limited by `intervalMinutes`) refine the title as more context accumulates. Convergence detection prevents churn in long sessions where the topic has settled. Setting `customName: true` in the state file lets other tooling or the user lock the title permanently.
+The first-prompt rename gives an immediate title from minimal signal. Subsequent renames (rate-limited by `intervalMinutes`) refine the title as more context accumulates. Convergence detection prevents churn in long sessions where the topic has settled. Setting `customName: true` in the state file lets other tooling or the user lock the title permanently. Automatic detection of manual renames via the host API is not yet implemented — `customName` is always `false` until set externally.
 </script>
   </div>
 
@@ -1881,7 +1881,7 @@ The first-prompt rename gives an immediate title from minimal signal. Subsequent
       <div class="reason"><span class="ri">&#x2022;</span> Reads per-session state from <code>MEMORY/STATE/session-rename-{sessionId}.json</code></div>
 <div class="reason"><span class="ri">&#x2022;</span> Extracts meaningful keywords from the incoming prompt (strips stop words and short tokens)</div>
 <div class="reason"><span class="ri">&#x2022;</span> Merges new keywords into the cumulative frequency map stored in state</div>
-<div class="reason"><span class="ri">&#x2022;</span> Decides whether to rename based on three guards: <code>enabled</code> flag, <code>customName</code> flag, and elapsed interval since last rename</div>
+<div class="reason"><span class="ri">&#x2022;</span> Decides whether to rename based on three guards: <code>enabled</code> flag, <code>customName</code> flag, and elapsed interval since last rename — note: <code>customName</code> detection is not yet implemented; the flag defaults to <code>false</code> and is never set to <code>true</code> by the current integration</div>
 <div class="reason"><span class="ri">&#x2022;</span> Builds a title from the top-5 most frequent keywords</div>
 <div class="reason"><span class="ri">&#x2022;</span> Returns <code>sessionTitle</code> in <code>hookSpecificOutput</code> when a rename is warranted</div>
 <div class="reason"><span class="ri">&#x2022;</span> Marks the session as <code>converged</code> once the same title appears <code>convergenceCount</code> times in a row — no further renames after that</div>
@@ -1906,7 +1906,7 @@ The first-prompt rename gives an immediate title from minimal signal. Subsequent
       </div>
       
       <div class="uc-example">
-        <div>User has manually set a session name — <code>customName: true</code> in state — hook exits immediately without overwriting it.</div>
+        <div>User has manually set a session name — <code>customName: true</code> in state — hook exits immediately without overwriting it. Note: automatic detection of manual renames is not yet implemented; <code>customName</code> must be set externally for this guard to trigger.</div>
       </div>
     </div>
   </section>

--- a/docs/groups/SessionFraming/SessionAutoRename.html
+++ b/docs/groups/SessionFraming/SessionAutoRename.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>pai-hooks — Documentation</title>
+  <title>SessionAutoRename — Hook Documentation</title>
   <style>@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap");
 
 /* ═══════════════════════════════════════════════════════
@@ -1742,257 +1742,275 @@ section[id] {
 }
 </style>
 </head>
-<body>
+<body class="has-sidebar">
 
+<nav class="wiki-nav" id="wikiNav">
+  <div class="wiki-nav-header">
+    <h4>SessionAutoRename</h4>
+    <p>SessionFraming / UserPromptSubmit</p>
+  </div>
+  <ul class="wiki-nav-list">
+    <li class="wiki-nav-item"><a href="#overview"><span class="nav-num">01</span> Overview</a></li>
+    <li class="wiki-nav-item"><a href="#event"><span class="nav-num">02</span> Event</a></li>
+    <li class="wiki-nav-item"><a href="#when-it-fires"><span class="nav-num">03</span> When It Fires</a></li>
+    <li class="wiki-nav-item"><a href="#what-it-does"><span class="nav-num">04</span> What It Does</a></li>
+    <li class="wiki-nav-item"><a href="#examples"><span class="nav-num">05</span> Examples</a></li>
+    <li class="wiki-nav-item"><a href="#dependencies"><span class="nav-num">06</span> Dependencies</a></li>
+  </ul>
+  <div class="wiki-nav-progress">
+    <div class="wiki-nav-progress-bar">
+      <div class="wiki-nav-progress-fill" id="navProgress"></div>
+    </div>
+    <div class="wiki-nav-progress-text" id="navProgressText">0% read</div>
+  </div>
+</nav>
+<div class="wiki-nav-overlay" id="navOverlay"></div>
+<button class="wiki-nav-toggle" id="navToggle" aria-label="Toggle navigation">&#9776;</button>
+<button class="back-to-top" id="backToTop" aria-label="Back to top">&#8593;</button>
 
 
 <div class="hero">
   <div class="hero-orb orb-1"></div>
   <div class="hero-orb orb-2"></div>
   <div class="container">
-    <div class="hero-badge"><span class="dot"></span> Documentation</div>
-    <h1>pai-hooks</h1>
-    <p>78 hooks across 24 groups.</p>
+    <div class="hero-badge"><span class="dot"></span> Hook Documentation</div>
+    <h1>SessionAutoRename</h1>
+    <p>Progressively renames sessions based on conversation content</p>
     <div class="hero-meta">
-      <span>March 2026</span>
-      <span>78 hooks</span>
-      <span>24 groups</span>
+      <span>SessionFraming</span>
+      <span>UserPromptSubmit</span>
+      <span>pai-hooks</span>
     </div>
   </div>
 </div>
 
 <div class="container">
-  <div class="summary-grid">
-    <div class="summary-item"><div class="num">24</div><div class="label">Groups</div></div>
-    <div class="summary-item"><div class="num">78</div><div class="label">Hooks</div></div>
+  <div class="tags" style="margin-bottom: var(--sp-md);">
+    <span class="tag accent">UserPromptSubmit</span>
+    <span class="tag green">SessionFraming</span>
+  </div>
+  <div style="margin-bottom: var(--sp-2xl); display: flex; align-items: center; gap: var(--sp-md);">
+    <a href="https://github.com/SaintPepsi/pai-hooks/tree/main/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.contract.ts" target="_blank" rel="noopener" style="color: var(--text-dim); font-size: 13px; text-decoration: none; display: inline-flex; align-items: center; gap: 6px;">
+      <span style="font-size: 15px;">&#x1F4C4;</span>
+      <code style="color: var(--cyan); font-size: 12px;">SessionAutoRename.contract.ts</code>
+      <span style="opacity: 0.5;">&#x2197;</span>
+    </a>
+    <button class="copy-idea-btn" onclick="copyIdea()">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+        <span>Copy Idea</span>
+      </button>
+      <script type="text/plain" id="ideaContent">## Problem
+
+Conversation sessions start with generic or empty titles. After a few exchanges the topic is clear, but there is no mechanism to retroactively name the session. Users end up with a history full of untitled or misleadingly-named sessions that are hard to navigate.
+
+## Solution
+
+A stateful hook that fires on every user prompt, accumulates keyword frequency across the session, and periodically proposes a title derived from the most-used meaningful words. The title evolves as the conversation evolves, then locks in once it stabilises.
+
+## How It Works
+
+1. On each user prompt submission the hook reads the per-session state file (or creates a fresh one).
+2. Keywords are extracted from the prompt: lowercased, punctuation stripped, stop words and tokens under 4 characters removed.
+3. New keywords are merged into a cumulative frequency map stored in state.
+4. Three early-exit guards are checked in order: hook disabled, session has a custom name set by the user, rename interval has not elapsed since last rename.
+5. If none of the guards fire, the top-5 keywords by frequency are joined into a candidate title.
+6. The title is returned as `sessionTitle` in the hook output so the host application can apply it immediately.
+7. The new title is appended to a `titleHistory` list. If the last N titles are identical the session is marked `converged` and no further renames are issued.
+8. Updated state (prompt count, keyword map, title history, convergence flag) is written back to the state file.
+
+## Signals
+
+Input:
+- `session_id` — used to locate the per-session state file
+- `prompt` / `user_prompt` — the raw text to extract keywords from
+- Config: `enabled`, `intervalMinutes` (default 15), `convergenceCount` (default 2)
+
+Output:
+- `hookSpecificOutput.sessionTitle` — the proposed title string, present only when a rename is warranted
+- `continue: true` — always set; this hook never blocks prompt submission
+
+## Context
+
+The first-prompt rename gives an immediate title from minimal signal. Subsequent renames (rate-limited by `intervalMinutes`) refine the title as more context accumulates. Convergence detection prevents churn in long sessions where the topic has settled. Setting `customName: true` in the state file lets other tooling or the user lock the title permanently.
+</script>
   </div>
 
-  <div class="section-label">Groups</div>
-  <h2>All Hook Groups</h2>
+  
 
   
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/AgentLifecycle/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>AgentLifecycle</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
-        </div>
-        <p>Agent spawn, stop, and permission management</p>
+  <section id="overview">
+    <div class="section-label accent">Overview</div>
+    <div class="card accent">
+      <div class="card-header">
+        <div class="card-icon">&#x1F4CB;</div>
+        <h3>Overview</h3>
       </div>
+      <p>Progressively renames the active Claude Code session based on keywords extracted from user prompts. The title builds up over time as the conversation evolves, and locks in once it stabilises.</p>
+    </div>
+  </section>
 
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/AlgorithmTracking/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>AlgorithmTracking</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span></div>
-        </div>
-        <p>PAI Algorithm phase detection</p>
+  <section id="event">
+    <div class="section-label cyan">Event</div>
+    <div class="card cyan">
+      <div class="card-header">
+        <div class="card-icon">&#x26A1;</div>
+        <h3>Event</h3>
       </div>
+      <p>UserPromptSubmit</p>
+    </div>
+  </section>
 
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/ArchitectureEscalation/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>ArchitectureEscalation</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span></div>
-        </div>
-        <p>Failure escalation and model delegation</p>
+  <section id="when-it-fires">
+    <div class="section-label orange">When It Fires</div>
+    <div class="card orange">
+      <div class="card-header">
+        <div class="card-icon">&#x1F3AF;</div>
+        <h3>When It Fires</h3>
       </div>
+      <p>On every user prompt submission. Most invocations are no-ops (interval guard, convergence guard). A rename is issued on the first prompt and then at most once per configured interval.</p>
+    </div>
+  </section>
 
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/CanaryHook/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>CanaryHook</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
-        </div>
-        <p>Debug canary for verifying hook propagation</p>
+  <section id="what-it-does">
+    <div class="section-label blue">What It Does</div>
+    <div class="card blue">
+      <div class="card-header">
+        <div class="card-icon">&#x2699;</div>
+        <h3>What It Does</h3>
       </div>
+      <div class="reason"><span class="ri">&#x2022;</span> Reads per-session state from <code>MEMORY/STATE/session-rename-{sessionId}.json</code></div>
+<div class="reason"><span class="ri">&#x2022;</span> Extracts meaningful keywords from the incoming prompt (strips stop words and short tokens)</div>
+<div class="reason"><span class="ri">&#x2022;</span> Merges new keywords into the cumulative frequency map stored in state</div>
+<div class="reason"><span class="ri">&#x2022;</span> Decides whether to rename based on three guards: <code>enabled</code> flag, <code>customName</code> flag, and elapsed interval since last rename</div>
+<div class="reason"><span class="ri">&#x2022;</span> Builds a title from the top-5 most frequent keywords</div>
+<div class="reason"><span class="ri">&#x2022;</span> Returns <code>sessionTitle</code> in <code>hookSpecificOutput</code> when a rename is warranted</div>
+<div class="reason"><span class="ri">&#x2022;</span> Marks the session as <code>converged</code> once the same title appears <code>convergenceCount</code> times in a row — no further renames after that</div>
+    </div>
+  </section>
 
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/CodeQualityPipeline/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>CodeQualityPipeline</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
-        </div>
-        <p>3 hooks</p>
+  <section id="examples">
+    <div class="section-label green">Examples</div>
+    <div class="card green">
+      <div class="card-header">
+        <div class="card-icon">&#x1F4A1;</div>
+        <h3>Examples</h3>
       </div>
+      
+      <div class="uc-example">
+        <div>First prompt of a session: "Implement the session auto-rename hook in TypeScript"</div>
+        <div>Title produced: "Implement Session Rename Typescript Hook"</div>
+      </div>
+      
+      <div class="uc-example">
+        <div>After several more prompts on the same topic, the title stabilises and convergence is detected — no further renames are issued for the rest of the session.</div>
+      </div>
+      
+      <div class="uc-example">
+        <div>User has manually set a session name — <code>customName: true</code> in state — hook exits immediately without overwriting it.</div>
+      </div>
+    </div>
+  </section>
 
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/CodingStandards/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>CodingStandards</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">7 hooks</span></div>
-        </div>
-        <p>TypeScript quality enforcement hooks</p>
+  <section id="dependencies">
+    <div class="section-label cyan">Dependencies</div>
+    <div class="card cyan">
+      <div class="card-header">
+        <div class="card-icon">&#x1F517;</div>
+        <h3>Dependencies</h3>
       </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/CronStatusLine/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>CronStatusLine</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">5 hooks</span></div>
-        </div>
-        <p>Cron job scheduling and status line management</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/DuplicationDetection/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>DuplicationDetection</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">2 hooks</span></div>
-        </div>
-        <p>Detect and prevent code duplication using SWC-based function analysis</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/ExecutionEvidence/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>ExecutionEvidence</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
-        </div>
-        <p>Execution evidence verification from tool results</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/GitSafety/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>GitSafety</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">7 hooks</span></div>
-        </div>
-        <p>Git safety, branch protection, and worktree verification</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/IdentityBranding/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>IdentityBranding</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
-        </div>
-        <p>Maple identity branding and usage analytics</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/KoordDaemon/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>KoordDaemon</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">6 hooks</span></div>
-        </div>
-        <p>Koord agent-to-agent daemon lifecycle hooks</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/LastResponseCache/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>LastResponseCache</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
-        </div>
-        <p>Last response caching for reference</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/LearningFeedback/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>LearningFeedback</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
-        </div>
-        <p>Learning signal capture and relationship memory</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/ObligationStateMachines/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>ObligationStateMachines</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">9 hooks</span></div>
-        </div>
-        <p>Documentation, test, citation, and hook-doc obligations</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/QuestionAnswered/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>QuestionAnswered</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
-        </div>
-        <p>User question response tracking</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/SecurityValidator/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>SecurityValidator</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">4 hooks</span></div>
-        </div>
-        <p>Protected file write prevention</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/SessionFraming/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>SessionFraming</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">5 hooks</span></div>
-        </div>
-        <p>Session initialization, context loading, and branch awareness</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/SkillGuard/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>SkillGuard</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
-        </div>
-        <p>Skill invocation validation</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/SteeringRuleInjector/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>SteeringRuleInjector</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
-        </div>
-        <p>Contextual steering rule injection based on event type and keyword matching</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/StopOrchestrator/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>StopOrchestrator</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
-        </div>
-        <p>Stop event coordination</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/VoiceGate/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>VoiceGate</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">1 hooks</span></div>
-        </div>
-        <p>Voice notification routing control</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/WikiPipeline/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>WikiPipeline</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">3 hooks</span></div>
-        </div>
-        <p>Wiki knowledge pipeline: session ingestion, context injection, and read tracking</p>
-      </div>
-
-      <div class="card accent" style="cursor:pointer;" onclick="location.href='groups/WorkLifecycle/index.html'">
-        <div class="card-header">
-          <div class="card-icon">&#x1F4C1;</div>
-          <h3>WorkLifecycle</h3>
-          <div class="card-badges"><span class="card-badge" style="background:var(--accent-glow);color:var(--accent-bright);">6 hooks</span></div>
-        </div>
-        <p>Session work tracking, summaries, and content generation</p>
-      </div>
+      <div class="reason"><span class="ri">&#x2022;</span> <code>MEMORY/STATE/session-rename-{sessionId}.json</code> — per-session keyword and title state</div>
+<div class="reason"><span class="ri">&#x2022;</span> <code>hookConfig.sessionAutoRename</code> in <code>settings.json</code> — optional config:</div>
+<div class="reason"><span class="ri">&#x2022;</span> <code>enabled</code> (boolean, default <code>true</code>)</div>
+<div class="reason"><span class="ri">&#x2022;</span> <code>intervalMinutes</code> (number, default <code>15</code>)</div>
+<div class="reason"><span class="ri">&#x2022;</span> <code>convergenceCount</code> (number, default <code>2</code>)</div>
+    </div>
+  </section>
 
   <footer>
-    <p>pai-hooks documentation</p>
-    <div class="collab"><span>pai-hooks</span></div>
+    <p>Generated from <code>SessionAutoRename/doc.md</code> &mdash; pai-hooks documentation</p>
   </footer>
 </div>
 
+<script>
+function copyIdea() {
+  var tpl = document.getElementById('ideaContent');
+  if (!tpl) return;
+  var text = tpl.textContent;
+  if (!text.trim()) return;
+  var done = function() {
+    var btn = document.querySelector('.copy-idea-btn span');
+    if (btn) { btn.textContent = 'Copied!'; setTimeout(function() { btn.textContent = 'Copy Idea'; }, 2000); }
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(done).catch(function() {
+      fallbackCopy(text); done();
+    });
+  } else { fallbackCopy(text); done(); }
+}
+function fallbackCopy(text) {
+  var ta = document.createElement('textarea');
+  ta.value = text; ta.style.position = 'fixed'; ta.style.opacity = '0';
+  document.body.appendChild(ta); ta.select(); document.execCommand('copy');
+  document.body.removeChild(ta);
+}
+</script>
 
+<script>
+(function() {
+  var nav = document.getElementById('wikiNav');
+  var toggle = document.getElementById('navToggle');
+  var overlay = document.getElementById('navOverlay');
+  var backToTop = document.getElementById('backToTop');
+  var progressFill = document.getElementById('navProgress');
+  var progressText = document.getElementById('navProgressText');
+  var navItems = document.querySelectorAll('.wiki-nav-item');
+  var sections = document.querySelectorAll('section[id]');
+
+  if (toggle) toggle.addEventListener('click', function() {
+    nav.classList.toggle('open');
+    overlay.classList.toggle('open');
+  });
+  if (overlay) overlay.addEventListener('click', function() {
+    nav.classList.remove('open');
+    overlay.classList.remove('open');
+  });
+  if (nav) nav.querySelectorAll('a').forEach(function(link) {
+    link.addEventListener('click', function() {
+      if (window.innerWidth <= 1200) {
+        nav.classList.remove('open');
+        overlay.classList.remove('open');
+      }
+    });
+  });
+
+  var ticking = false;
+  window.addEventListener('scroll', function() {
+    if (!ticking) {
+      requestAnimationFrame(function() {
+        var scrollTop = window.scrollY;
+        var docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        var progress = docHeight > 0 ? Math.min(100, Math.round((scrollTop / docHeight) * 100)) : 0;
+        if (progressFill) progressFill.style.width = progress + '%';
+        if (progressText) progressText.textContent = progress + '% read';
+        if (backToTop) backToTop.classList.toggle('visible', scrollTop > 400);
+        var current = '';
+        for (var i = 0; i < sections.length; i++) {
+          if (sections[i].getBoundingClientRect().top <= 120) current = sections[i].id;
+        }
+        navItems.forEach(function(item) {
+          var link = item.querySelector('a');
+          item.classList.toggle('active', link && link.getAttribute('href') === '#' + current);
+        });
+        ticking = false;
+      });
+      ticking = true;
+    }
+  });
+
+  if (backToTop) backToTop.addEventListener('click', function() {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+})();
+</script>
 </body>
 </html>

--- a/docs/groups/SessionFraming/index.html
+++ b/docs/groups/SessionFraming/index.html
@@ -1754,7 +1754,7 @@ section[id] {
     <h1>SessionFraming</h1>
     <p>Session initialization, context loading, and branch awareness</p>
     <div class="hero-meta">
-      <span>4 hooks</span>
+      <span>5 hooks</span>
       <span>pai-hooks</span>
     </div>
   </div>
@@ -1771,6 +1771,7 @@ section[id] {
 
   <div class="summary-grid">
     <div class="summary-item"><div class="num" style="color:var(--green);">4</div><div class="label">SessionStart</div></div>
+    <div class="summary-item"><div class="num" style="color:var(--accent-bright);">1</div><div class="label">UserPromptSubmit</div></div>
   </div>
 
   <div class="section-label">Hooks</div>
@@ -1819,6 +1820,17 @@ section[id] {
           </div>
         </div>
         <p>Loads PAI context files at session start</p>
+      </div>
+
+      <div class="card accent" style="cursor:pointer;" onclick="location.href='SessionAutoRename.html'">
+        <div class="card-header">
+          <div class="card-icon">&#x1F517;</div>
+          <h3>SessionAutoRename</h3>
+          <div class="card-badges">
+            <span class="card-badge" style="background:var(--accent-dim);color:var(--accent);">UserPromptSubmit</span>
+          </div>
+        </div>
+        <p>Progressively renames sessions based on conversation content</p>
       </div>
 
   <footer><p>pai-hooks documentation</p></footer>

--- a/hooks/SessionFraming/SessionAutoRename/IDEA.md
+++ b/hooks/SessionFraming/SessionAutoRename/IDEA.md
@@ -11,7 +11,7 @@ A stateful hook that fires on every user prompt, accumulates keyword frequency a
 1. On each user prompt submission the hook reads the per-session state file (or creates a fresh one).
 2. Keywords are extracted from the prompt: lowercased, punctuation stripped, stop words and tokens under 4 characters removed.
 3. New keywords are merged into a cumulative frequency map stored in state.
-4. Three early-exit guards are checked in order: hook disabled, session has a custom name set by the user, rename interval has not elapsed since last rename.
+4. Three early-exit guards are checked in order: hook disabled, session has a custom name set by the user (`customName` flag in state — not yet automatically detected; must be set externally), rename interval has not elapsed since last rename.
 5. If none of the guards fire, the top-5 keywords by frequency are joined into a candidate title.
 6. The title is returned as `sessionTitle` in the hook output so the host application can apply it immediately.
 7. The new title is appended to a `titleHistory` list. If the last N titles are identical the session is marked `converged` and no further renames are issued.
@@ -30,4 +30,4 @@ Output:
 
 ## Context
 
-The first-prompt rename gives an immediate title from minimal signal. Subsequent renames (rate-limited by `intervalMinutes`) refine the title as more context accumulates. Convergence detection prevents churn in long sessions where the topic has settled. Setting `customName: true` in the state file lets other tooling or the user lock the title permanently.
+The first-prompt rename gives an immediate title from minimal signal. Subsequent renames (rate-limited by `intervalMinutes`) refine the title as more context accumulates. Convergence detection prevents churn in long sessions where the topic has settled. Setting `customName: true` in the state file lets other tooling or the user lock the title permanently. Automatic detection of manual renames via the host API is not yet implemented — `customName` is always `false` until set externally.

--- a/hooks/SessionFraming/SessionAutoRename/IDEA.md
+++ b/hooks/SessionFraming/SessionAutoRename/IDEA.md
@@ -1,0 +1,33 @@
+## Problem
+
+Conversation sessions start with generic or empty titles. After a few exchanges the topic is clear, but there is no mechanism to retroactively name the session. Users end up with a history full of untitled or misleadingly-named sessions that are hard to navigate.
+
+## Solution
+
+A stateful hook that fires on every user prompt, accumulates keyword frequency across the session, and periodically proposes a title derived from the most-used meaningful words. The title evolves as the conversation evolves, then locks in once it stabilises.
+
+## How It Works
+
+1. On each user prompt submission the hook reads the per-session state file (or creates a fresh one).
+2. Keywords are extracted from the prompt: lowercased, punctuation stripped, stop words and tokens under 4 characters removed.
+3. New keywords are merged into a cumulative frequency map stored in state.
+4. Three early-exit guards are checked in order: hook disabled, session has a custom name set by the user, rename interval has not elapsed since last rename.
+5. If none of the guards fire, the top-5 keywords by frequency are joined into a candidate title.
+6. The title is returned as `sessionTitle` in the hook output so the host application can apply it immediately.
+7. The new title is appended to a `titleHistory` list. If the last N titles are identical the session is marked `converged` and no further renames are issued.
+8. Updated state (prompt count, keyword map, title history, convergence flag) is written back to the state file.
+
+## Signals
+
+Input:
+- `session_id` — used to locate the per-session state file
+- `prompt` / `user_prompt` — the raw text to extract keywords from
+- Config: `enabled`, `intervalMinutes` (default 15), `convergenceCount` (default 2)
+
+Output:
+- `hookSpecificOutput.sessionTitle` — the proposed title string, present only when a rename is warranted
+- `continue: true` — always set; this hook never blocks prompt submission
+
+## Context
+
+The first-prompt rename gives an immediate title from minimal signal. Subsequent renames (rate-limited by `intervalMinutes`) refine the title as more context accumulates. Convergence detection prevents churn in long sessions where the topic has settled. Setting `customName: true` in the state file lets other tooling or the user lock the title permanently.

--- a/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.contract.ts
+++ b/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.contract.ts
@@ -130,6 +130,8 @@ export function shouldRename(
   nowMs: number,
 ): boolean {
   if (state.converged) return false;
+  // TODO: customName is always false — no integration sets it to true yet.
+  // Future: detect manual renames via the host API and set customName: true in state.
   if (state.customName) return false;
 
   const intervalMs = (config.intervalMinutes ?? DEFAULT_INTERVAL_MINUTES) * 60 * 1000;
@@ -217,8 +219,14 @@ export const SessionAutoRename: SyncHookContract<UserPromptSubmitInput, SessionA
 
     // Persist state
     const stateDir = join(deps.baseDir, "MEMORY", "STATE");
-    deps.ensureDir(stateDir);
-    deps.writeJson(statePath, state);
+    const dirResult = deps.ensureDir(stateDir);
+    if (!dirResult.ok) {
+      deps.stderr(`[SessionAutoRename] Failed to ensure state directory: ${dirResult.error.message}`);
+    }
+    const writeResult = deps.writeJson(statePath, state);
+    if (!writeResult.ok) {
+      deps.stderr(`[SessionAutoRename] Failed to save state: ${writeResult.error.message}`);
+    }
 
     if (sessionTitle) {
       return ok({

--- a/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.contract.ts
+++ b/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.contract.ts
@@ -1,0 +1,237 @@
+/**
+ * SessionAutoRename Contract — Progressive session renaming from prompt content.
+ *
+ * UserPromptSubmit hook that extracts keywords from user prompts and builds a
+ * running title for the session. Returns sessionTitle in hookSpecificOutput
+ * when a rename is warranted. Tracks state in MEMORY/STATE per session and
+ * marks converged once the title stabilises across N consecutive prompts.
+ */
+
+import { join } from "node:path";
+import type { SyncHookJSONOutput } from "@anthropic-ai/claude-agent-sdk";
+import { ensureDir, fileExists, readJson, writeJson } from "@hooks/core/adapters/fs";
+import type { SyncHookContract } from "@hooks/core/contract";
+import type { ResultError } from "@hooks/core/error";
+import { ok, type Result } from "@hooks/core/result";
+import type { UserPromptSubmitInput } from "@hooks/core/types/hook-inputs";
+import { readHookConfig } from "@hooks/lib/hook-config";
+import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SessionRenameState {
+  promptCount: number;
+  firstSeenAt: number;
+  lastRenameAt: number;
+  renameCount: number;
+  titleHistory: string[];
+  converged: boolean;
+  customName: boolean;
+  /** Accumulated keyword frequency map (serialised as object). */
+  keywords: Record<string, number>;
+}
+
+interface SessionAutoRenameConfig {
+  enabled?: boolean;
+  intervalMinutes?: number;
+  convergenceCount?: number;
+}
+
+export interface SessionAutoRenameDeps {
+  fileExists: (path: string) => boolean;
+  readJson: <T = unknown>(path: string) => Result<T, ResultError>;
+  writeJson: (path: string, data: unknown) => Result<void, ResultError>;
+  ensureDir: (path: string) => Result<void, ResultError>;
+  readConfig: () => SessionAutoRenameConfig | null;
+  now: () => number;
+  baseDir: string;
+  stderr: (msg: string) => void;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_INTERVAL_MINUTES = 15;
+const DEFAULT_CONVERGENCE_COUNT = 2;
+
+const STOP_WORDS = new Set([
+  "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for",
+  "of", "with", "by", "from", "up", "about", "into", "through", "is",
+  "are", "was", "were", "be", "been", "being", "have", "has", "had",
+  "do", "does", "did", "will", "would", "could", "should", "may", "might",
+  "can", "this", "that", "these", "those", "i", "me", "my", "we", "our",
+  "you", "your", "it", "its", "not", "no", "so", "if", "as", "just",
+  "also", "then", "than", "very", "more", "some", "how", "what", "which",
+  "who", "when", "where", "why", "all", "any", "each", "few", "most",
+  "other", "own", "same", "such", "both", "only", "over", "under", "again",
+  "here", "there", "once", "now", "please", "use", "make", "get", "let",
+  "need", "want", "like", "look", "help", "add", "run", "check",
+]);
+
+// ─── Pure Logic ──────────────────────────────────────────────────────────────
+
+export function getStatePath(sessionId: string, baseDir: string): string {
+  return join(baseDir, "MEMORY", "STATE", `session-rename-${sessionId}.json`);
+}
+
+function emptyState(now: number): SessionRenameState {
+  return {
+    promptCount: 0,
+    firstSeenAt: now,
+    lastRenameAt: 0,
+    renameCount: 0,
+    titleHistory: [],
+    converged: false,
+    customName: false,
+    keywords: {},
+  };
+}
+
+export function extractKeywords(prompt: string): string[] {
+  return prompt
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((w) => w.length > 3 && !STOP_WORDS.has(w));
+}
+
+export function mergeKeywords(
+  existing: Record<string, number>,
+  newWords: string[],
+): Record<string, number> {
+  const updated = { ...existing };
+  for (const word of newWords) {
+    updated[word] = (updated[word] ?? 0) + 1;
+  }
+  return updated;
+}
+
+export function buildTitle(keywords: Record<string, number>): string | null {
+  const sorted = Object.entries(keywords)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([word]) => word);
+
+  if (sorted.length === 0) return null;
+
+  // Capitalise first letter of each word
+  const words = sorted.map((w) => w.charAt(0).toUpperCase() + w.slice(1));
+  return words.join(" ");
+}
+
+export function isConverged(titleHistory: string[], convergenceCount: number): boolean {
+  if (titleHistory.length < convergenceCount) return false;
+  const recent = titleHistory.slice(-convergenceCount);
+  return recent.every((t) => t === recent[0]);
+}
+
+export function shouldRename(
+  state: SessionRenameState,
+  config: SessionAutoRenameConfig,
+  nowMs: number,
+): boolean {
+  if (state.converged) return false;
+  if (state.customName) return false;
+
+  const intervalMs = (config.intervalMinutes ?? DEFAULT_INTERVAL_MINUTES) * 60 * 1000;
+
+  // Always rename on first prompt (lastRenameAt === 0)
+  if (state.lastRenameAt === 0) return true;
+
+  return nowMs - state.lastRenameAt >= intervalMs;
+}
+
+// ─── Contract ────────────────────────────────────────────────────────────────
+
+const defaultDeps: SessionAutoRenameDeps = {
+  fileExists,
+  readJson,
+  writeJson,
+  ensureDir,
+  readConfig: () => readHookConfig<SessionAutoRenameConfig>("sessionAutoRename"),
+  now: () => Date.now(),
+  baseDir: getPaiDir(),
+  stderr: defaultStderr,
+};
+
+export const SessionAutoRename: SyncHookContract<UserPromptSubmitInput, SessionAutoRenameDeps> = {
+  name: "SessionAutoRename",
+  event: "UserPromptSubmit",
+
+  accepts(_input: UserPromptSubmitInput): boolean {
+    return true;
+  },
+
+  execute(
+    input: UserPromptSubmitInput,
+    deps: SessionAutoRenameDeps,
+  ): Result<SyncHookJSONOutput, ResultError> {
+    const config = deps.readConfig() ?? {};
+
+    // Respect enabled flag — default to true
+    if (config.enabled === false) {
+      return ok({ continue: true });
+    }
+
+    const sessionId = input.session_id;
+    const statePath = getStatePath(sessionId, deps.baseDir);
+    const nowMs = deps.now();
+
+    // Load or create state
+    let state: SessionRenameState;
+    if (deps.fileExists(statePath)) {
+      const loaded = deps.readJson<SessionRenameState>(statePath);
+      state = loaded.ok ? loaded.value : emptyState(nowMs);
+    } else {
+      state = emptyState(nowMs);
+    }
+
+    // Extract keywords from this prompt
+    const prompt = input.prompt || input.user_prompt || "";
+    const newWords = extractKeywords(prompt);
+
+    // Update state
+    state.promptCount += 1;
+    state.keywords = mergeKeywords(state.keywords, newWords);
+
+    const shouldDoRename = shouldRename(state, config, nowMs);
+
+    let sessionTitle: string | undefined;
+
+    if (shouldDoRename) {
+      const title = buildTitle(state.keywords);
+      if (title) {
+        sessionTitle = title;
+        state.lastRenameAt = nowMs;
+        state.renameCount += 1;
+        state.titleHistory = [...state.titleHistory, title];
+
+        const convergenceCount = config.convergenceCount ?? DEFAULT_CONVERGENCE_COUNT;
+        if (isConverged(state.titleHistory, convergenceCount)) {
+          state.converged = true;
+          deps.stderr(`[SessionAutoRename] Converged on title: "${title}"`);
+        } else {
+          deps.stderr(`[SessionAutoRename] Renamed to: "${title}"`);
+        }
+      }
+    }
+
+    // Persist state
+    const stateDir = join(deps.baseDir, "MEMORY", "STATE");
+    deps.ensureDir(stateDir);
+    deps.writeJson(statePath, state);
+
+    if (sessionTitle) {
+      return ok({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: "UserPromptSubmit",
+          sessionTitle,
+        },
+      });
+    }
+
+    return ok({ continue: true });
+  },
+
+  defaultDeps,
+};

--- a/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.hook.ts
+++ b/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.hook.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bun
+import { runHook } from "@hooks/core/runner";
+import { SessionAutoRename } from "@hooks/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.contract";
+
+if (import.meta.main) {
+  runHook(SessionAutoRename).catch((e) => {
+    process.stderr.write(`[hook] fatal: ${e instanceof Error ? e.message : e}\n`);
+    process.exit(0);
+  });
+}

--- a/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.test.ts
+++ b/hooks/SessionFraming/SessionAutoRename/SessionAutoRename.test.ts
@@ -1,0 +1,430 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ErrorCode, ResultError } from "@hooks/core/error";
+import { err, ok, type Result } from "@hooks/core/result";
+import type { UserPromptSubmitInput } from "@hooks/core/types/hook-inputs";
+
+/** Wrap a state value so its readJson mock satisfies the generic dep signature. */
+function mockReadJson(
+  value: SessionRenameState,
+): SessionAutoRenameDeps["readJson"] {
+  return mock(() => ok(value)) as unknown as SessionAutoRenameDeps["readJson"];
+}
+import {
+  buildTitle,
+  extractKeywords,
+  getStatePath,
+  isConverged,
+  mergeKeywords,
+  type SessionAutoRenameDeps,
+  SessionAutoRename,
+  type SessionRenameState,
+  shouldRename,
+} from "./SessionAutoRename.contract";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const BASE_DIR = "/tmp/test-pai";
+const SESSION_ID = "sess-abc123";
+const NOW = 1_700_000_000_000;
+
+function makeInput(
+  prompt: string,
+  overrides: Partial<UserPromptSubmitInput> = {},
+): UserPromptSubmitInput {
+  return { session_id: SESSION_ID, prompt, ...overrides };
+}
+
+function makeState(overrides: Partial<SessionRenameState> = {}): SessionRenameState {
+  return {
+    promptCount: 0,
+    firstSeenAt: NOW - 60_000,
+    lastRenameAt: 0,
+    renameCount: 0,
+    titleHistory: [],
+    converged: false,
+    customName: false,
+    keywords: {},
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<SessionAutoRenameDeps> = {}): SessionAutoRenameDeps {
+  return {
+    fileExists: mock(() => false),
+    readJson: mock(() => err(new ResultError(ErrorCode.FileNotFound, "not found"))),
+    writeJson: mock(() => ok(undefined)),
+    ensureDir: mock(() => ok(undefined)),
+    readConfig: mock(() => null),
+    now: mock(() => NOW),
+    baseDir: BASE_DIR,
+    stderr: mock(() => {}),
+    ...overrides,
+  };
+}
+
+// ─── getStatePath ─────────────────────────────────────────────────────────────
+
+describe("getStatePath", () => {
+  it("returns correct MEMORY/STATE path", () => {
+    const p = getStatePath("my-session", "/home/user/.claude");
+    expect(p).toBe("/home/user/.claude/MEMORY/STATE/session-rename-my-session.json");
+  });
+});
+
+// ─── extractKeywords ──────────────────────────────────────────────────────────
+
+describe("extractKeywords", () => {
+  it("lowercases and splits words", () => {
+    const kws = extractKeywords("Implement the Feature");
+    expect(kws).toContain("implement");
+    expect(kws).toContain("feature");
+  });
+
+  it("filters stop words", () => {
+    const kws = extractKeywords("and the is are with");
+    expect(kws).toHaveLength(0);
+  });
+
+  it("filters words shorter than 4 chars", () => {
+    const kws = extractKeywords("fix bug add run");
+    // "fix", "bug", "add", "run" are all <= 3 chars or in stop words
+    expect(kws).toHaveLength(0);
+  });
+
+  it("strips punctuation", () => {
+    const kws = extractKeywords("implement session-rename hook!");
+    expect(kws).toContain("implement");
+    expect(kws).toContain("session");
+    expect(kws).toContain("rename");
+    expect(kws).toContain("hook");
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(extractKeywords("")).toHaveLength(0);
+  });
+});
+
+// ─── mergeKeywords ────────────────────────────────────────────────────────────
+
+describe("mergeKeywords", () => {
+  it("adds new words with count 1", () => {
+    const result = mergeKeywords({}, ["typescript", "testing"]);
+    expect(result.typescript).toBe(1);
+    expect(result.testing).toBe(1);
+  });
+
+  it("increments existing word counts", () => {
+    const result = mergeKeywords({ typescript: 2 }, ["typescript"]);
+    expect(result.typescript).toBe(3);
+  });
+
+  it("does not mutate existing object", () => {
+    const existing = { typescript: 1 };
+    mergeKeywords(existing, ["typescript"]);
+    expect(existing.typescript).toBe(1);
+  });
+});
+
+// ─── buildTitle ───────────────────────────────────────────────────────────────
+
+describe("buildTitle", () => {
+  it("returns null for empty keywords", () => {
+    expect(buildTitle({})).toBeNull();
+  });
+
+  it("capitalises first letter of each word", () => {
+    const title = buildTitle({ typescript: 3, testing: 2 });
+    expect(title).toBe("Typescript Testing");
+  });
+
+  it("picks top 5 by frequency", () => {
+    const kws = {
+      alpha: 10, beta: 9, gamma: 8, delta: 7, epsilon: 6,
+      zeta: 1, eta: 1,
+    };
+    const title = buildTitle(kws);
+    expect(title).not.toContain("Zeta");
+    expect(title).not.toContain("Eta");
+    expect(title).toContain("Alpha");
+  });
+
+  it("handles single keyword", () => {
+    expect(buildTitle({ typescript: 5 })).toBe("Typescript");
+  });
+});
+
+// ─── isConverged ─────────────────────────────────────────────────────────────
+
+describe("isConverged", () => {
+  it("returns false when history shorter than convergenceCount", () => {
+    expect(isConverged(["Title One"], 2)).toBe(false);
+  });
+
+  it("returns true when last N titles are identical", () => {
+    expect(isConverged(["Old Title", "New Title", "New Title"], 2)).toBe(true);
+  });
+
+  it("returns false when last N titles differ", () => {
+    expect(isConverged(["Title A", "Title B"], 2)).toBe(false);
+  });
+
+  it("returns true with convergenceCount 3", () => {
+    expect(isConverged(["X", "Y", "Z", "Z", "Z"], 3)).toBe(true);
+  });
+});
+
+// ─── shouldRename ─────────────────────────────────────────────────────────────
+
+describe("shouldRename", () => {
+  it("returns true on first prompt (lastRenameAt === 0)", () => {
+    expect(shouldRename(makeState(), {}, NOW)).toBe(true);
+  });
+
+  it("returns false when already converged", () => {
+    expect(shouldRename(makeState({ converged: true }), {}, NOW)).toBe(false);
+  });
+
+  it("returns false when customName is set", () => {
+    expect(shouldRename(makeState({ customName: true }), {}, NOW)).toBe(false);
+  });
+
+  it("returns false when interval not elapsed", () => {
+    const state = makeState({ lastRenameAt: NOW - 5 * 60 * 1000 }); // 5 min ago
+    expect(shouldRename(state, { intervalMinutes: 15 }, NOW)).toBe(false);
+  });
+
+  it("returns true when interval has elapsed", () => {
+    const state = makeState({ lastRenameAt: NOW - 20 * 60 * 1000 }); // 20 min ago
+    expect(shouldRename(state, { intervalMinutes: 15 }, NOW)).toBe(true);
+  });
+});
+
+// ─── SessionAutoRename.accepts ────────────────────────────────────────────────
+
+describe("SessionAutoRename.accepts", () => {
+  it("always returns true", () => {
+    expect(SessionAutoRename.accepts(makeInput("anything"))).toBe(true);
+    expect(SessionAutoRename.accepts(makeInput(""))).toBe(true);
+  });
+});
+
+// ─── execute: disabled ────────────────────────────────────────────────────────
+
+describe("SessionAutoRename.execute — disabled", () => {
+  it("returns continue:true without sessionTitle when enabled:false", () => {
+    const deps = makeDeps({ readConfig: mock(() => ({ enabled: false })) });
+    const result = SessionAutoRename.execute(makeInput("implement a new feature"), deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.continue).toBe(true);
+    expect(result.value.hookSpecificOutput).toBeUndefined();
+  });
+
+  it("does not write state when disabled", () => {
+    const deps = makeDeps({ readConfig: mock(() => ({ enabled: false })) });
+    SessionAutoRename.execute(makeInput("implement a new feature"), deps);
+    expect((deps.writeJson as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+});
+
+// ─── execute: first prompt rename ─────────────────────────────────────────────
+
+describe("SessionAutoRename.execute — first prompt rename", () => {
+  it("returns sessionTitle on first meaningful prompt", () => {
+    const deps = makeDeps();
+    const result = SessionAutoRename.execute(
+      makeInput("implement session rename feature typescript"),
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.hookSpecificOutput?.hookEventName).toBe("UserPromptSubmit");
+    // Type narrowing — sessionTitle is on UserPromptSubmit specific output
+    const hs = result.value.hookSpecificOutput;
+    if (hs && "sessionTitle" in hs) {
+      expect(typeof hs.sessionTitle).toBe("string");
+      expect((hs.sessionTitle ?? "").length).toBeGreaterThan(0);
+    }
+  });
+
+  it("persists state to writeJson", () => {
+    const deps = makeDeps();
+    SessionAutoRename.execute(makeInput("implement feature typescript"), deps);
+
+    const calls = (deps.writeJson as ReturnType<typeof mock>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const [writePath, writeData] = calls[0];
+    expect(writePath).toContain(`session-rename-${SESSION_ID}`);
+    expect((writeData as SessionRenameState).promptCount).toBe(1);
+    expect((writeData as SessionRenameState).renameCount).toBe(1);
+  });
+
+  it("calls ensureDir for state directory", () => {
+    const deps = makeDeps();
+    SessionAutoRename.execute(makeInput("implement feature"), deps);
+
+    const calls = (deps.ensureDir as ReturnType<typeof mock>).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect((calls[0][0] as string)).toContain("MEMORY/STATE");
+  });
+});
+
+// ─── execute: no rename when interval not elapsed ─────────────────────────────
+
+describe("SessionAutoRename.execute — interval guard", () => {
+  it("returns no sessionTitle when interval has not elapsed", () => {
+    const existingState = makeState({
+      lastRenameAt: NOW - 5 * 60 * 1000, // 5 min ago
+      promptCount: 3,
+      keywords: { typescript: 5, implement: 4, feature: 3 },
+    });
+
+    const deps = makeDeps({
+      fileExists: mock(() => true),
+      readJson: mockReadJson(existingState),
+      readConfig: mock(() => ({ intervalMinutes: 15 })),
+    });
+
+    const result = SessionAutoRename.execute(makeInput("check it out"), deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.hookSpecificOutput).toBeUndefined();
+  });
+
+  it("still writes updated state (promptCount incremented) even without rename", () => {
+    const existingState = makeState({
+      lastRenameAt: NOW - 5 * 60 * 1000,
+      promptCount: 3,
+      keywords: { typescript: 5 },
+    });
+
+    const deps = makeDeps({
+      fileExists: mock(() => true),
+      readJson: mockReadJson(existingState),
+      readConfig: mock(() => ({ intervalMinutes: 15 })),
+    });
+
+    SessionAutoRename.execute(makeInput("check it out"), deps);
+
+    const calls = (deps.writeJson as ReturnType<typeof mock>).mock.calls;
+    expect(calls.length).toBe(1);
+    expect((calls[0][1] as SessionRenameState).promptCount).toBe(4);
+  });
+});
+
+// ─── execute: convergence ─────────────────────────────────────────────────────
+
+describe("SessionAutoRename.execute — convergence", () => {
+  it("marks converged after N identical titles", () => {
+    // History already has (convergenceCount - 1) identical titles.
+    // Keyword weights are high enough that adding a few new words won't
+    // displace the top-5, keeping the title identical.
+    const existingState = makeState({
+      lastRenameAt: NOW - 20 * 60 * 1000, // eligible for rename
+      renameCount: 1,
+      titleHistory: ["Typescript Feature"],
+      keywords: { typescript: 100, feature: 90 },
+    });
+
+    const deps = makeDeps({
+      fileExists: mock(() => true),
+      readJson: mockReadJson(existingState),
+      readConfig: mock(() => ({ intervalMinutes: 15, convergenceCount: 2 })),
+    });
+
+    // Prompt adds "typescript" and "feature" again — title stays identical
+    SessionAutoRename.execute(makeInput("typescript feature"), deps);
+
+    const calls = (deps.writeJson as ReturnType<typeof mock>).mock.calls;
+    const savedState = calls[0][1] as SessionRenameState;
+    expect(savedState.converged).toBe(true);
+  });
+
+  it("returns no sessionTitle once converged", () => {
+    const existingState = makeState({ converged: true });
+
+    const deps = makeDeps({
+      fileExists: mock(() => true),
+      readJson: mockReadJson(existingState),
+    });
+
+    const result = SessionAutoRename.execute(makeInput("more work here please"), deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.hookSpecificOutput).toBeUndefined();
+  });
+});
+
+// ─── execute: customName guard ────────────────────────────────────────────────
+
+describe("SessionAutoRename.execute — customName guard", () => {
+  it("returns no sessionTitle when customName is set", () => {
+    const existingState = makeState({ customName: true });
+
+    const deps = makeDeps({
+      fileExists: mock(() => true),
+      readJson: mockReadJson(existingState),
+    });
+
+    const result = SessionAutoRename.execute(makeInput("work on typescript feature"), deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.hookSpecificOutput).toBeUndefined();
+  });
+});
+
+// ─── execute: corrupted state falls back gracefully ───────────────────────────
+
+describe("SessionAutoRename.execute — resilience", () => {
+  it("creates fresh state when stored state is corrupted", () => {
+    const deps = makeDeps({
+      fileExists: mock(() => true),
+      readJson: mock(() => err(new ResultError(ErrorCode.JsonParseFailed, "corrupt json"))),
+    });
+
+    const result = SessionAutoRename.execute(makeInput("implement feature typescript"), deps);
+
+    expect(result.ok).toBe(true);
+    // Should still attempt a rename with fresh state
+    if (!result.ok) return;
+    const hs = result.value.hookSpecificOutput;
+    if (hs && "sessionTitle" in hs) {
+      expect(hs.sessionTitle).toBeDefined();
+    }
+  });
+
+  it("always returns continue:true regardless of outcome", () => {
+    const deps = makeDeps({
+      writeJson: mock(() => err(new ResultError(ErrorCode.FileWriteFailed, "disk full"))),
+    });
+
+    const result = SessionAutoRename.execute(makeInput("implement feature"), deps);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.continue).toBe(true);
+  });
+});
+
+// ─── execute: empty / short prompt ───────────────────────────────────────────
+
+describe("SessionAutoRename.execute — empty prompt", () => {
+  it("returns no sessionTitle for prompt with no extractable keywords", () => {
+    const deps = makeDeps();
+    const result = SessionAutoRename.execute(makeInput(""), deps);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.hookSpecificOutput).toBeUndefined();
+  });
+
+  it("returns continue:true for empty prompt", () => {
+    const deps = makeDeps();
+    const result = SessionAutoRename.execute(makeInput(""), deps);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.continue).toBe(true);
+  });
+});

--- a/hooks/SessionFraming/SessionAutoRename/doc.md
+++ b/hooks/SessionFraming/SessionAutoRename/doc.md
@@ -15,7 +15,7 @@ On every user prompt submission. Most invocations are no-ops (interval guard, co
 - Reads per-session state from `MEMORY/STATE/session-rename-{sessionId}.json`
 - Extracts meaningful keywords from the incoming prompt (strips stop words and short tokens)
 - Merges new keywords into the cumulative frequency map stored in state
-- Decides whether to rename based on three guards: `enabled` flag, `customName` flag, and elapsed interval since last rename
+- Decides whether to rename based on three guards: `enabled` flag, `customName` flag, and elapsed interval since last rename — note: `customName` detection is not yet implemented; the flag defaults to `false` and is never set to `true` by the current integration
 - Builds a title from the top-5 most frequent keywords
 - Returns `sessionTitle` in `hookSpecificOutput` when a rename is warranted
 - Marks the session as `converged` once the same title appears `convergenceCount` times in a row — no further renames after that
@@ -27,7 +27,7 @@ On every user prompt submission. Most invocations are no-ops (interval guard, co
 
 > After several more prompts on the same topic, the title stabilises and convergence is detected — no further renames are issued for the rest of the session.
 
-> User has manually set a session name — `customName: true` in state — hook exits immediately without overwriting it.
+> User has manually set a session name — `customName: true` in state — hook exits immediately without overwriting it. Note: automatic detection of manual renames is not yet implemented; `customName` must be set externally for this guard to trigger.
 
 ## Dependencies
 

--- a/hooks/SessionFraming/SessionAutoRename/doc.md
+++ b/hooks/SessionFraming/SessionAutoRename/doc.md
@@ -1,0 +1,38 @@
+## Overview
+
+Progressively renames the active Claude Code session based on keywords extracted from user prompts. The title builds up over time as the conversation evolves, and locks in once it stabilises.
+
+## Event
+
+UserPromptSubmit
+
+## When It Fires
+
+On every user prompt submission. Most invocations are no-ops (interval guard, convergence guard). A rename is issued on the first prompt and then at most once per configured interval.
+
+## What It Does
+
+- Reads per-session state from `MEMORY/STATE/session-rename-{sessionId}.json`
+- Extracts meaningful keywords from the incoming prompt (strips stop words and short tokens)
+- Merges new keywords into the cumulative frequency map stored in state
+- Decides whether to rename based on three guards: `enabled` flag, `customName` flag, and elapsed interval since last rename
+- Builds a title from the top-5 most frequent keywords
+- Returns `sessionTitle` in `hookSpecificOutput` when a rename is warranted
+- Marks the session as `converged` once the same title appears `convergenceCount` times in a row — no further renames after that
+
+## Examples
+
+> First prompt of a session: "Implement the session auto-rename hook in TypeScript"
+> Title produced: "Implement Session Rename Typescript Hook"
+
+> After several more prompts on the same topic, the title stabilises and convergence is detected — no further renames are issued for the rest of the session.
+
+> User has manually set a session name — `customName: true` in state — hook exits immediately without overwriting it.
+
+## Dependencies
+
+- `MEMORY/STATE/session-rename-{sessionId}.json` — per-session keyword and title state
+- `hookConfig.sessionAutoRename` in `settings.json` — optional config:
+  - `enabled` (boolean, default `true`)
+  - `intervalMinutes` (number, default `15`)
+  - `convergenceCount` (number, default `2`)

--- a/hooks/SessionFraming/SessionAutoRename/hook.json
+++ b/hooks/SessionFraming/SessionAutoRename/hook.json
@@ -1,0 +1,9 @@
+{
+  "name": "SessionAutoRename",
+  "group": "SessionFraming",
+  "event": "UserPromptSubmit",
+  "description": "Progressively renames sessions based on conversation content",
+  "schemaVersion": 1,
+  "tags": [],
+  "presets": []
+}

--- a/hooks/SessionFraming/group.json
+++ b/hooks/SessionFraming/group.json
@@ -1,6 +1,6 @@
 {
   "name": "SessionFraming",
   "description": "Session initialization, context loading, and branch awareness",
-  "hooks": ["BranchAwareness", "CheckVersion", "GitignoreRecommender", "LoadContext"],
+  "hooks": ["BranchAwareness", "CheckVersion", "GitignoreRecommender", "LoadContext", "SessionAutoRename"],
   "sharedFiles": []
 }


### PR DESCRIPTION
## Summary

- Adds `SessionAutoRename` — a `UserPromptSubmit` hook that extracts keywords from user prompts and progressively builds a session title
- Returns `sessionTitle` in `hookSpecificOutput` on first prompt and then at most once per configured interval (default 15 min); stops renaming once the title converges across N identical consecutive values (default 2)
- Per-session state stored in `MEMORY/STATE/session-rename-{sessionId}.json`; configurable via `hookConfig.sessionAutoRename` in `settings.json`

## Test plan

- [x] 37 unit tests pass (100% line coverage on contract)
- [x] Full suite: 4058 pass, 3 pre-existing failures unrelated to this change
- [x] `tsc --noEmit`: 0 new errors introduced (5 total vs 10 pre-existing baseline)
- [x] `bun run docs:check`: 78/78 hooks documented
- [ ] Smoke test: start a session and send a few prompts — verify title updates in Claude Code UI
- [ ] Verify convergence: send prompts on same topic until title stabilises, confirm no further renames
- [ ] Verify `enabled: false` in `hookConfig.sessionAutoRename` disables renames entirely

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple