### PR TITLE
feat(config): add typed hookConfig schema validation (#124)

### DIFF
--- a/core/error.test.ts
+++ b/core/error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   cancelled,
+  configValidationFailed,
   contractViolation,
   dirCreateFailed,
   ErrorCode,
@@ -25,9 +26,9 @@ import {
 // ─── ErrorCode Enum ──────────────────────────────────────────────────────────
 
 describe("ErrorCode", () => {
-  it("has 18 error codes", () => {
+  it("has 19 error codes", () => {
     const codes = Object.keys(ErrorCode).filter((k) => Number.isNaN(Number(k)));
-    expect(codes.length).toBe(18);
+    expect(codes.length).toBe(19);
   });
 
   it("all codes are unique string values", () => {
@@ -192,9 +193,24 @@ describe("factory functions", () => {
     expect(e.code).toBe(ErrorCode.Cancelled);
     expect(e.message).toBe("user abort");
   });
+
+  it("configValidationFailed includes hookName and cause message", () => {
+    const cause = new Error("Expected boolean");
+    const e = configValidationFailed("myHook", cause);
+    expect(e.code).toBe(ErrorCode.ConfigValidationFailed);
+    expect(e.message).toContain("myHook");
+    expect(e.message).toContain("Expected boolean");
+    expect(e.cause).toBe(cause);
+  });
+
+  it("configValidationFailed stringifies non-Error cause", () => {
+    const e = configValidationFailed("myHook", "parse error");
+    expect(e.code).toBe(ErrorCode.ConfigValidationFailed);
+    expect(e.message).toContain("parse error");
+  });
 });
 
-// ─── All 18 factories produce correct codes ──────────────────────────────────
+// ─── All 19 factories produce correct codes ──────────────────────────────────
 
 describe("factory → code mapping", () => {
   const mappings: [() => ResultError, ErrorCode][] = [
@@ -216,10 +232,11 @@ describe("factory → code mapping", () => {
     [() => stateCorrupted("x", null), ErrorCode.StateCorrupted],
     [() => unknownError("x"), ErrorCode.Unknown],
     [() => cancelled("x"), ErrorCode.Cancelled],
+    [() => configValidationFailed("myHook", new Error("bad")), ErrorCode.ConfigValidationFailed],
   ];
 
-  it("has 18 factory mappings", () => {
-    expect(mappings.length).toBe(18);
+  it("has 19 factory mappings", () => {
+    expect(mappings.length).toBe(19);
   });
 
   for (const [factory, expectedCode] of mappings) {

--- a/core/error.ts
+++ b/core/error.ts
@@ -33,6 +33,7 @@ export enum ErrorCode {
   SecurityBlock = "SECURITY_BLOCK",
   ContractViolation = "CONTRACT_VIOLATION",
   StateCorrupted = "STATE_CORRUPTED",
+  ConfigValidationFailed = "CONFIG_VALIDATION_FAILED",
 
   // System
   Unknown = "UNKNOWN",
@@ -131,4 +132,13 @@ export function unknownError(cause: unknown): ResultError {
 
 export function cancelled(reason: string): ResultError {
   return new ResultError(ErrorCode.Cancelled, reason);
+}
+
+export function configValidationFailed(hookName: string, cause: unknown): ResultError {
+  const msg = cause instanceof Error ? cause.message : String(cause);
+  return new ResultError(
+    ErrorCode.ConfigValidationFailed,
+    `Config validation failed for "${hookName}": ${msg}`,
+    cause,
+  );
 }

--- a/core/index.ts
+++ b/core/index.ts
@@ -33,6 +33,7 @@ export type { HookContract } from "@hooks/core/contract";
 // Error types
 export {
   cancelled,
+  configValidationFailed,
   contractViolation,
   dirCreateFailed,
   ErrorCode,

--- a/lib/hook-config.test.ts
+++ b/lib/hook-config.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for lib/hook-config.ts — typed and untyped config reading.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { Schema } from "effect";
+import { ErrorCode } from "@hooks/core/error";
+import { readHookConfig } from "@hooks/lib/hook-config";
+
+// ─── Test Helpers ────────────────────────────────────────────────────────────
+
+function makeReader(settings: Record<string, unknown>): (path: string) => string | null {
+  return () => JSON.stringify(settings);
+}
+
+function makeFailReader(): (path: string) => string | null {
+  return () => null;
+}
+
+function makeInvalidJsonReader(): (path: string) => string | null {
+  return () => "not-json{{{";
+}
+
+const TestSchema = Schema.Struct({
+  blocking: Schema.Boolean,
+  threshold: Schema.optional(Schema.Number),
+});
+
+type TestConfig = typeof TestSchema.Type;
+
+// ─── Untyped overload ────────────────────────────────────────────────────────
+
+describe("readHookConfig (untyped)", () => {
+  it("returns config object when present", () => {
+    const reader = makeReader({
+      hookConfig: { myHook: { blocking: true } },
+    });
+    const result = readHookConfig("myHook", reader);
+    expect(result).toEqual({ blocking: true });
+  });
+
+  it("returns null when hookConfig key is missing", () => {
+    const reader = makeReader({ hookConfig: {} });
+    const result = readHookConfig("missingHook", reader);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when hookConfig is absent", () => {
+    const reader = makeReader({});
+    const result = readHookConfig("myHook", reader);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when file cannot be read", () => {
+    const result = readHookConfig("myHook", makeFailReader());
+    expect(result).toBeNull();
+  });
+
+  it("returns null on invalid JSON", () => {
+    const result = readHookConfig("myHook", makeInvalidJsonReader());
+    expect(result).toBeNull();
+  });
+
+  it("returns null when config value is not an object", () => {
+    const reader = makeReader({ hookConfig: { myHook: "a string" } });
+    const result = readHookConfig("myHook", reader);
+    expect(result).toBeNull();
+  });
+
+  it("passes settingsPath override to reader", () => {
+    let capturedPath: string | null = null;
+    const reader = (path: string): string | null => {
+      capturedPath = path;
+      return JSON.stringify({ hookConfig: { myHook: { val: 1 } } });
+    };
+    readHookConfig("myHook", reader, "/custom/path/settings.json");
+    expect(capturedPath!).toBe("/custom/path/settings.json");
+  });
+});
+
+// ─── Typed overload (with Schema) ────────────────────────────────────────────
+
+describe("readHookConfig (with Schema)", () => {
+  it("returns ok(config) when config is valid", () => {
+    const reader = makeReader({
+      hookConfig: { myHook: { blocking: true, threshold: 5 } },
+    });
+    const result = readHookConfig("myHook", TestSchema, reader);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.blocking).toBe(true);
+      expect(result.value.threshold).toBe(5);
+    }
+  });
+
+  it("returns ok when optional field is absent", () => {
+    const reader = makeReader({
+      hookConfig: { myHook: { blocking: false } },
+    });
+    const result = readHookConfig("myHook", TestSchema, reader);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.blocking).toBe(false);
+      expect(result.value.threshold).toBeUndefined();
+    }
+  });
+
+  it("returns err(ConfigValidationFailed) when config is missing", () => {
+    const reader = makeReader({ hookConfig: {} });
+    const result = readHookConfig("missingHook", TestSchema, reader);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCode.ConfigValidationFailed);
+    }
+  });
+
+  it("returns err(ConfigValidationFailed) when schema validation fails", () => {
+    const reader = makeReader({
+      hookConfig: { myHook: { blocking: "not-a-boolean" } },
+    });
+    const result = readHookConfig("myHook", TestSchema, reader);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCode.ConfigValidationFailed);
+      expect(result.error.message).toContain("myHook");
+    }
+  });
+
+  it("returns err(ConfigValidationFailed) when file cannot be read", () => {
+    const result = readHookConfig("myHook", TestSchema, makeFailReader());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCode.ConfigValidationFailed);
+    }
+  });
+
+  it("returns err(ConfigValidationFailed) when JSON is invalid", () => {
+    const result = readHookConfig("myHook", TestSchema, makeInvalidJsonReader());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe(ErrorCode.ConfigValidationFailed);
+    }
+  });
+
+  it("passes settingsPath override to reader", () => {
+    let capturedPath: string | null = null;
+    const reader = (path: string): string | null => {
+      capturedPath = path;
+      return JSON.stringify({ hookConfig: { myHook: { blocking: true } } });
+    };
+    readHookConfig("myHook", TestSchema, reader, "/custom/path/settings.json");
+    expect(capturedPath!).toBe("/custom/path/settings.json");
+  });
+
+  it("error message includes hookName", () => {
+    const reader = makeReader({ hookConfig: { wrongHook: { blocking: true } } });
+    const result = readHookConfig("myHook", TestSchema, reader);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("myHook");
+    }
+  });
+});
+
+// ─── Type narrowing via overload ─────────────────────────────────────────────
+
+describe("readHookConfig overload resolution", () => {
+  it("untyped overload returns T | null (not Result)", () => {
+    const reader = makeReader({ hookConfig: { h: { x: 1 } } });
+    const result = readHookConfig<{ x: number }>("h", reader);
+    // If this were a Result, it would have an `ok` property — we check it doesn't
+    expect(result).not.toHaveProperty("ok");
+    expect(result).toEqual({ x: 1 });
+  });
+
+  it("typed overload returns Result (not plain object)", () => {
+    const reader = makeReader({ hookConfig: { h: { blocking: true } } });
+    const result = readHookConfig("h", TestSchema, reader);
+    expect(result).toHaveProperty("ok");
+  });
+});

--- a/lib/hook-config.ts
+++ b/lib/hook-config.ts
@@ -2,14 +2,18 @@
  * Shared hook configuration reader.
  *
  * Reads settings.json, parses JSON, and navigates to
- * hookConfig.{hookName} in a single call. Returns null
- * if not configured or on any read/parse error.
+ * hookConfig.{hookName} in a single call.
+ *
+ * Two overloads:
+ *   - Without schema: returns T | null (existing behavior, fail-open)
+ *   - With schema: returns Result<T, ResultError> (validated, fail-explicit)
  */
 
 import { readFile } from "@hooks/core/adapters/fs";
-import { jsonParseFailed } from "@hooks/core/error";
-import { tryCatch } from "@hooks/core/result";
+import { configValidationFailed, jsonParseFailed, type ResultError } from "@hooks/core/error";
+import { err, ok, type Result, tryCatch } from "@hooks/core/result";
 import { getSettingsPath } from "@hooks/lib/paths";
+import { Schema } from "effect";
 
 interface SettingsWithHookConfig {
   hookConfig?: Record<string, unknown>;
@@ -29,7 +33,68 @@ export function readHookConfig<T = Record<string, unknown>>(
   hookName: string,
   readFileFn?: (path: string) => string | null,
   settingsPath?: string,
-): T | null {
+): T | null;
+
+/**
+ * Read and validate a hook's config section from settings.json.
+ *
+ * Like the untyped overload but validates against `schema` using Effect Schema.
+ * Returns `Result<T, ResultError>` — ok on success, err with
+ * `ConfigValidationFailed` if the config is missing or fails validation.
+ *
+ * @param hookName - The key under hookConfig (e.g. "duplicationChecker")
+ * @param schema - Effect Schema to validate against
+ * @param readFileFn - Optional file reader override (for testing/DI)
+ * @param settingsPath - Optional settings path override (for testing)
+ */
+export function readHookConfig<T>(
+  hookName: string,
+  schema: Schema.Schema<T>,
+  readFileFn?: (path: string) => string | null,
+  settingsPath?: string,
+): Result<T, ResultError>;
+
+export function readHookConfig<T>(
+  hookName: string,
+  schemaOrReadFileFn?: Schema.Schema<T> | ((path: string) => string | null),
+  readFileFnOrSettingsPath?: ((path: string) => string | null) | string,
+  settingsPath?: string,
+): T | null | Result<T, ResultError> {
+  // Detect which overload was called by checking if second arg is an Effect Schema.
+  // Schemas are functions (not plain functions) — Schema.isSchema correctly distinguishes
+  // them from the readFileFn option in the untyped overload.
+  const isSchemaOverload =
+    schemaOrReadFileFn !== undefined && Schema.isSchema(schemaOrReadFileFn);
+
+  if (isSchemaOverload) {
+    const schema = schemaOrReadFileFn as Schema.Schema<T>;
+    const readFileFn = readFileFnOrSettingsPath as ((path: string) => string | null) | undefined;
+    const resolvedSettingsPath = settingsPath;
+    const raw = readRaw(hookName, readFileFn, resolvedSettingsPath);
+    if (raw === null) {
+      return err(configValidationFailed(hookName, new Error("Hook config not found")));
+    }
+    const decode = Schema.decodeUnknownEither(schema);
+    const result = decode(raw);
+    if (result._tag === "Right") return ok(result.right);
+    return err(configValidationFailed(hookName, result.left));
+  }
+
+  // Untyped overload
+  const readFileFn = schemaOrReadFileFn as ((path: string) => string | null) | undefined;
+  const resolvedSettingsPath = readFileFnOrSettingsPath as string | undefined;
+  return readRaw(hookName, readFileFn, resolvedSettingsPath) as T | null;
+}
+
+/**
+ * Internal helper: reads and extracts the raw hookConfig.{hookName} object.
+ * Returns the raw value (unknown object) or null on any error.
+ */
+function readRaw(
+  hookName: string,
+  readFileFn?: (path: string) => string | null,
+  settingsPath?: string,
+): Record<string, unknown> | null {
   const path = settingsPath ?? getSettingsPath();
   const reader =
     readFileFn ??
@@ -48,5 +113,5 @@ export function readHookConfig<T = Record<string, unknown>>(
 
   const cfg = parseResult.value?.hookConfig?.[hookName];
   if (!cfg || typeof cfg !== "object") return null;
-  return cfg as T;
+  return cfg as Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

- Adds `ConfigValidationFailed` error code and `configValidationFailed` factory to `core/error.ts`
- Adds overloaded `readHookConfig` in `lib/hook-config.ts`: without schema returns `T | null` (existing behavior), with `Schema.Schema<T>` returns `Result<T, ResultError>` with validated config
- Exports new error code and factory from `core/index.ts`
- Adds `lib/hook-config.test.ts` with 17 tests covering both overloads, validation failure paths, and overload resolution

## Test plan

- [x] `bun test lib/hook-config.test.ts` — 17/17 pass
- [x] `bun test core/error.test.ts` — all pass (count updated to 19)
- [x] `bun test` (full suite) — 4040 pass, 3 pre-existing failures (QuestionAnswered shell tests, CLI 6-tuple test), no regressions
- [x] `npx tsc --noEmit` — only pre-existing errors in `DocObligationStateMachine.ts`, none from our changes

Closes #124

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple