### PR TITLE
feat(test-obligation): add import-aware test detection (#85)

### DIFF
--- a/hooks/ObligationStateMachines/TestObligationEnforcer/TestObligationEnforcer.contract.ts
+++ b/hooks/ObligationStateMachines/TestObligationEnforcer/TestObligationEnforcer.contract.ts
@@ -8,6 +8,7 @@ import {
   blockCountPath,
   buildBlockLimitReview,
   defaultDeps,
+  findImportingTestFile,
   hasTestFile,
   MAX_BLOCKS,
   pendingPath,
@@ -55,6 +56,8 @@ export const TestObligationEnforcer: SyncHookContract<StopInput, TestObligationD
 
     for (const file of pending) {
       if (hasTestFile(file, deps.fileExists)) {
+        needsRunning.push(file);
+      } else if (findImportingTestFile(file, deps) !== null) {
         needsRunning.push(file);
       } else {
         needsWriting.push(file);

--- a/hooks/ObligationStateMachines/TestObligationEnforcer/TestObligationEnforcer.test.ts
+++ b/hooks/ObligationStateMachines/TestObligationEnforcer/TestObligationEnforcer.test.ts
@@ -13,6 +13,8 @@ function makeDeps(overrides: Partial<TestObligationDeps> = {}): TestObligationDe
   return {
     stateDir: "/tmp/test-state",
     fileExists: () => true,
+    readDir: () => [],
+    readFileContent: () => null,
     readPending: () => ["src/module.ts"],
     writePending: () => {},
     removeFlag: () => {},
@@ -111,5 +113,60 @@ describe("TestObligationEnforcer", () => {
     if (result.ok) expect(isBareNoOp(result.value)).toBe(true);
     expect(reviewWritten).toBe(true);
     expect(flagRemoved).toBe(true);
+  });
+
+  test("blocks with 'run tests' when source is imported by a nearby test file", () => {
+    const deps = makeDeps({
+      readPending: () => ["src/utils.ts"],
+      fileExists: (path) => {
+        // Flag file exists, but no co-located test file for src/utils.ts
+        if (
+          path.endsWith(".test.ts") ||
+          path.endsWith(".spec.ts") ||
+          path.endsWith(".test.tsx") ||
+          path.endsWith(".coverage.test.ts")
+        )
+          return false;
+        return true;
+      },
+      // Simulate a nearby test file that imports utils
+      readDir: (_dir) => ["utils.test.ts"],
+      readFileContent: (_path) => `import { something } from './utils';`,
+    });
+    const result = TestObligationEnforcer.execute(mockInput, deps);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const reason = getReasonFromBlock(result.value);
+      expect(reason).toBeDefined();
+      expect(reason ?? "").toContain("Run existing tests");
+      expect(reason ?? "").toContain("src/utils.ts");
+    }
+  });
+
+  test("blocks with 'write tests' when no co-located or importing test file exists", () => {
+    const deps = makeDeps({
+      readPending: () => ["src/orphan.ts"],
+      fileExists: (path) => {
+        // Flag file exists, but no test file variant exists
+        if (
+          path.endsWith(".test.ts") ||
+          path.endsWith(".spec.ts") ||
+          path.endsWith(".test.tsx") ||
+          path.endsWith(".coverage.test.ts")
+        )
+          return false;
+        return true;
+      },
+      readDir: () => [],
+      readFileContent: () => null,
+    });
+    const result = TestObligationEnforcer.execute(mockInput, deps);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const reason = getReasonFromBlock(result.value);
+      expect(reason).toBeDefined();
+      expect(reason ?? "").toContain("Write and run tests");
+      expect(reason ?? "").toContain("src/orphan.ts");
+    }
   });
 });

--- a/hooks/ObligationStateMachines/TestObligationStateMachine.shared.ts
+++ b/hooks/ObligationStateMachines/TestObligationStateMachine.shared.ts
@@ -3,9 +3,10 @@
  * Used by both TestObligationTracker and TestObligationEnforcer.
  */
 
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import {
   fileExists as fsFileExists,
+  readDir as fsReadDir,
   readFile,
   readJson,
   removeFile,
@@ -18,8 +19,16 @@ import { defaultStderr, getPaiDir } from "@hooks/lib/paths";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-// TestObligationDeps is ObligationDeps from lib/obligation-machine.ts
-export type TestObligationDeps = ObligationDeps;
+/** Deps for scanning nearby test files for imports of a source file. */
+export interface ImportScanDeps {
+  /** Return filenames (not full paths) in a directory, or [] on error. */
+  readDir: (dirPath: string) => string[];
+  /** Return file content as a string, or null on error. */
+  readFileContent: (filePath: string) => string | null;
+}
+
+// TestObligationDeps extends ObligationDeps with import-scan capabilities.
+export type TestObligationDeps = ObligationDeps & ImportScanDeps;
 
 /** Narrow extension used only by TestObligationTracker (not the enforcer). */
 export interface TestTrackerExcludeDeps {
@@ -150,6 +159,52 @@ export function hasTestFile(sourcePath: string, fileExists: (path: string) => bo
   return deriveTestPaths(sourcePath).some(fileExists);
 }
 
+/**
+ * Scan the same directory and parent directory for *.test.ts / *.spec.ts files
+ * that import the given source file. Returns the path of the first match, or null.
+ *
+ * The regex matches:
+ *   import ... from '...basename...'
+ *   require('...basename...')
+ *
+ * For `.contract.ts` sources the `.contract` suffix is stripped when deriving
+ * the basename to match, mirroring the convention in `deriveTestPaths`.
+ */
+export function findImportingTestFile(
+  sourcePath: string,
+  deps: ImportScanDeps,
+): string | null {
+  // Derive the import name the test file would use. Strip extension, then strip
+  // `.contract` suffix when present (matches the co-located test convention).
+  const dotIndex = sourcePath.lastIndexOf(".");
+  const withoutExt = dotIndex === -1 ? sourcePath : sourcePath.slice(0, dotIndex);
+  const stem = withoutExt.endsWith(".contract")
+    ? withoutExt.slice(0, -".contract".length)
+    : withoutExt;
+  // Use the final path component as the import basename to match against.
+  const importBasename = basename(stem).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const importPattern = new RegExp(
+    `from\\s+['"][^'"]*${importBasename}['"]|require\\(['"][^'"]*${importBasename}['"]\\)`,
+  );
+
+  const testFilePattern = /\.(?:test|spec)\.\w+$/;
+  const sourceDir = dirname(sourcePath);
+  const parentDir = dirname(sourceDir);
+
+  for (const dir of [sourceDir, parentDir]) {
+    const entries = deps.readDir(dir);
+    for (const entry of entries) {
+      if (!testFilePattern.test(entry)) continue;
+      const fullPath = join(dir, entry);
+      const content = deps.readFileContent(fullPath);
+      if (content !== null && importPattern.test(content)) {
+        return fullPath;
+      }
+    }
+  }
+  return null;
+}
+
 // ─── Exclude Pattern Helpers ──────────────────────────────────────────────────
 
 /** Read excludePatterns from settings.json hookConfig.testObligation.excludePatterns. */
@@ -182,6 +237,14 @@ export const defaultTrackerExcludeDeps: TestTrackerExcludeDeps = {
 export const defaultDeps: TestObligationDeps = {
   stateDir: getStateDir(getPaiDir()),
   fileExists: (path: string) => fsFileExists(path),
+  readDir: (dirPath: string) => {
+    const result = fsReadDir(dirPath);
+    return result.ok ? result.value : [];
+  },
+  readFileContent: (filePath: string) => {
+    const result = readFile(filePath);
+    return result.ok ? result.value : null;
+  },
   readPending: (path: string) => {
     const result = readJson<unknown>(path);
     if (!result.ok) {

--- a/hooks/ObligationStateMachines/TestObligationStateMachine.shared.ts
+++ b/hooks/ObligationStateMachines/TestObligationStateMachine.shared.ts
@@ -184,7 +184,7 @@ export function findImportingTestFile(
   // Use the final path component as the import basename to match against.
   const importBasename = basename(stem).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const importPattern = new RegExp(
-    `from\\s+['"][^'"]*${importBasename}['"]|require\\(['"][^'"]*${importBasename}['"]\\)`,
+    `from\\s+['"](?:[^'"]*\\/)?${importBasename}['"]|require\\(['"](?:[^'"]*\\/)?${importBasename}['"]\\)`,
   );
 
   const testFilePattern = /\.(?:test|spec)\.\w+$/;

--- a/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.test.ts
+++ b/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.test.ts
@@ -21,6 +21,8 @@ function makeTrackerDeps(overrides: Partial<TestTrackerDeps> = {}): TestTrackerD
   return {
     stateDir: "/tmp/pai-test-obligation",
     fileExists: () => false,
+    readDir: () => [],
+    readFileContent: () => null,
     readPending: () => [],
     writePending: () => {},
     removeFlag: () => {},

--- a/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.test.ts
+++ b/hooks/ObligationStateMachines/TestObligationTracker/TestObligationStateMachine.test.ts
@@ -1070,3 +1070,38 @@ describe("deriveTestPaths", () => {
     expect(deriveTestPaths("/abs/path/README")).toEqual([]);
   });
 });
+
+// ─── findImportingTestFile ──────────────────────────────────────────────────
+
+describe("findImportingTestFile", () => {
+  it("returns null when test imports changelog but source is log.ts (substring false-positive)", () => {
+    const {
+      findImportingTestFile,
+    } = require("@hooks/hooks/ObligationStateMachines/TestObligationStateMachine.shared");
+
+    const deps = {
+      readDir: (_dir: string) => ["changelog.test.ts"],
+      readFileContent: (_path: string) =>
+        "import { something } from '@hooks/lib/changelog';\n",
+    };
+
+    const result = findImportingTestFile("/src/log.ts", deps);
+    expect(result).toBeNull();
+  });
+
+  it("returns matching test file when test imports Foo and source is Foo.contract.ts", () => {
+    const {
+      findImportingTestFile,
+    } = require("@hooks/hooks/ObligationStateMachines/TestObligationStateMachine.shared");
+
+    const deps = {
+      readDir: (_dir: string) => ["Foo.test.ts"],
+      readFileContent: (_path: string) =>
+        "import { Foo } from '@hooks/hooks/SomeGroup/Foo';\n",
+    };
+
+    const result = findImportingTestFile("/src/Foo.contract.ts", deps);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Foo.test.ts");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ImportScanDeps` interface (`readDir`, `readFileContent`) to `TestObligationStateMachine.shared.ts`
- Adds `findImportingTestFile` helper that scans the same dir and parent dir for `*.test.ts`/`*.spec.ts` files importing the source file
- Extends `TestObligationDeps` to include `ImportScanDeps` and wires real implementations into `defaultDeps`
- Updates `TestObligationEnforcer.contract.ts` to fall through to `findImportingTestFile` when `hasTestFile` returns false, pushing matches to `needsRunning` instead of `needsWriting`
- Adds `readDir`/`readFileContent` defaults to `makeDeps` in both enforcer and tracker test factories, plus two new enforcer tests covering the import-aware path

## Test plan

- [ ] `bun test hooks/ObligationStateMachines/TestObligationEnforcer` — 10 pass, 0 fail
- [ ] `npx tsc --noEmit` — no new errors (pre-existing `DocObligationStateMachine.ts` errors unrelated to this PR)
- [ ] New test: source imported by nearby test file → categorized as `needsRunning`
- [ ] New test: no co-located or importing test file → categorized as `needsWriting`

Closes #85

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple