### PR TITLE
feat(DuplicationChecker): automated false-positive triage (#111)

### DIFF
--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
@@ -4,7 +4,7 @@
  * Signal thresholds (4 dimensions: hash, name, sig, body):
  *   - 1/4: ignore
  *   - 2/4 or 3/4: log to file only
- *   - 4/4: block
+ *   - 4/4: block (with optional inference triage to suppress false positives)
  *
  * Thin contract shell. Logic lives in:
  *   - shared.ts: index loading, checking, formatting, tool input helpers
@@ -18,9 +18,9 @@ import {
   readFile as adapterReadFile,
   fileExists,
 } from "@hooks/core/adapters/fs";
-import type { SyncHookContract } from "@hooks/core/contract";
+import type { AsyncHookContract } from "@hooks/core/contract";
 import type { ResultError } from "@hooks/core/error";
-import { ok, type Result } from "@hooks/core/result";
+import { ok, tryCatchAsync, type Result } from "@hooks/core/result";
 import type { ToolHookInput } from "@hooks/core/types/hook-inputs";
 import { extractFunctions } from "@hooks/hooks/DuplicationDetection/parser";
 import {
@@ -30,6 +30,7 @@ import {
   getArtifactsDir,
   getCurrentBranch,
   loadIndex,
+  type DuplicationMatch,
   type PatternEntry,
   simulateEdit,
 } from "@hooks/hooks/DuplicationDetection/shared";
@@ -37,6 +38,8 @@ import { readHookConfig } from "@hooks/lib/hook-config";
 import { pickNarrative } from "@hooks/lib/narrative-reader";
 import { defaultStderr } from "@hooks/lib/paths";
 import { getFilePath, getWriteContent } from "@hooks/lib/tool-input";
+import type { InferenceOptions, InferenceResult } from "@pai/Tools/Inference";
+import { inference as stubInference } from "@pai/Tools/Inference";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -49,6 +52,12 @@ export interface DuplicationCheckerDeps {
   now: () => number;
   /** When true, 4/4 signal matches block the operation. When false, they log only. */
   blocking: boolean;
+  /** When true, inference triage runs on block-worthy matches to suppress false positives. */
+  inferenceEnabled: boolean;
+  /** Inference function — injected for testing. */
+  inference: (opts: InferenceOptions) => Promise<InferenceResult>;
+  /** When true, false-positive reports are written to /tmp/pai/duplication/fp-reports/. */
+  issueReporting: boolean;
 }
 
 // ─── Config ─────────────────────────────────────────────────────────────────
@@ -56,6 +65,109 @@ export interface DuplicationCheckerDeps {
 function readBlockingConfig(): boolean {
   const cfg = readHookConfig<{ blocking?: boolean }>("duplicationChecker");
   return cfg?.blocking !== false;
+}
+
+function readInferenceConfig(): boolean {
+  const cfg = readHookConfig<{ inferenceEnabled?: boolean }>("duplicationChecker");
+  return cfg?.inferenceEnabled === true;
+}
+
+// ─── Inference Triage ────────────────────────────────────────────────────────
+
+type TriageVerdict = "true_positive" | "false_positive" | "uncertain";
+
+async function classifyMatches(
+  blockMatches: DuplicationMatch[],
+  content: string,
+  filePath: string,
+  deps: DuplicationCheckerDeps,
+): Promise<TriageVerdict> {
+  const matchDescriptions = blockMatches
+    .map(
+      (m) =>
+        `Function "${m.functionName}" in ${filePath} duplicates "${m.targetName}" in ${m.targetFile} (line ${m.targetLine}, signals: ${m.signals.join(", ")})`,
+    )
+    .join("\n");
+
+  const prompt = [
+    "You are a code duplication triage assistant.",
+    "Determine if the following duplication detection result is a true positive (real duplicate that should be refactored) or a false positive (legitimate code that appears similar but serves a distinct purpose).",
+    "",
+    "Duplication findings:",
+    matchDescriptions,
+    "",
+    "File being written:",
+    "```typescript",
+    content.slice(0, 2000),
+    "```",
+    "",
+    'Respond with JSON only: { "verdict": "true_positive" | "false_positive" | "uncertain", "reason": "brief explanation" }',
+  ].join("\n");
+
+  const result = await tryCatchAsync(
+    () => deps.inference({ prompt, level: "fast", timeout: 4000 }),
+    () => null,
+  );
+
+  if (!result.ok || !result.value || !result.value.success || !result.value.output) {
+    return "uncertain";
+  }
+
+  const parseResult = tryCatchAsync(
+    async () => {
+      const raw = result.value!.parsed ?? JSON.parse(result.value!.output);
+      return (raw as { verdict?: string }).verdict;
+    },
+    () => null,
+  );
+
+  const parsed = await parseResult;
+  if (!parsed.ok || parsed.value === null) return "uncertain";
+
+  const verdict = parsed.value;
+  if (verdict === "true_positive" || verdict === "false_positive" || verdict === "uncertain") {
+    return verdict;
+  }
+  return "uncertain";
+}
+
+// ─── False Positive Reporting ────────────────────────────────────────────────
+
+function createFalsePositiveReport(
+  blockMatches: DuplicationMatch[],
+  filePath: string,
+  deps: DuplicationCheckerDeps,
+): void {
+  if (!deps.issueReporting) return;
+
+  const hash = blockMatches.map((m) => `${m.functionName}:${m.targetFile}`).join("|");
+  const reportDir = "/tmp/pai/duplication/fp-reports";
+  const safeHash = hash.slice(0, 32).replace(/[^a-zA-Z0-9]/g, "_");
+  const lockPath = `${reportDir}/${safeHash}.lock`;
+
+  deps.ensureDir(reportDir);
+
+  if (deps.exists(lockPath)) {
+    const content = deps.readFile(lockPath);
+    if (content) {
+      const ts = parseInt(content.trim(), 10);
+      const sevenDays = 7 * 24 * 60 * 60 * 1000;
+      if (!isNaN(ts) && deps.now() - ts < sevenDays) return;
+    }
+  }
+
+  deps.appendFile(lockPath, String(deps.now()));
+
+  const report = {
+    ts: new Date(deps.now()).toISOString(),
+    file: filePath,
+    matches: blockMatches.map((m) => ({
+      fn: m.functionName,
+      target: `${m.targetFile}:${m.targetName}`,
+      signals: m.signals,
+    })),
+  };
+  deps.appendFile(`${reportDir}/${safeHash}.report.json`, JSON.stringify(report, null, 2));
 }
 
 // ─── Contract ───────────────────────────────────────────────────────────────
@@ -75,9 +187,12 @@ const defaultDeps: DuplicationCheckerDeps = {
   stderr: defaultStderr,
   now: () => Date.now(),
   blocking: readBlockingConfig(),
+  inferenceEnabled: readInferenceConfig(),
+  inference: stubInference,
+  issueReporting: false,
 };
 
-export const DuplicationCheckerContract: SyncHookContract<ToolHookInput, DuplicationCheckerDeps> = {
+export const DuplicationCheckerContract: AsyncHookContract<ToolHookInput, DuplicationCheckerDeps> = {
   name: "DuplicationChecker",
   event: "PreToolUse",
 
@@ -90,10 +205,10 @@ export const DuplicationCheckerContract: SyncHookContract<ToolHookInput, Duplica
     return true;
   },
 
-  execute(
+  async execute(
     input: ToolHookInput,
     deps: DuplicationCheckerDeps,
-  ): Result<SyncHookJSONOutput, ResultError> {
+  ): Promise<Result<SyncHookJSONOutput, ResultError>> {
     const filePath = getFilePath(input)!;
 
     const indexPath = findIndexPath(filePath, deps);
@@ -226,6 +341,26 @@ export const DuplicationCheckerContract: SyncHookContract<ToolHookInput, Duplica
       ].join("\n");
 
       if (deps.blocking) {
+        if (deps.inferenceEnabled) {
+          const verdict = await classifyMatches(blockMatches, content, filePath, deps);
+          if (verdict === "false_positive") {
+            createFalsePositiveReport(blockMatches, filePath, deps);
+            deps.stderr(
+              `[DuplicationChecker] ${filePath}: inference triage — false positive, allowing write`,
+            );
+            return ok({
+              continue: true,
+              hookSpecificOutput: {
+                hookEventName: "PreToolUse",
+                additionalContext:
+                  "Duplication triage: inference classified this as a false positive — write allowed. The flagged functions appear similar but serve distinct purposes.",
+              },
+            });
+          }
+          deps.stderr(
+            `[DuplicationChecker] ${filePath}: inference triage — ${verdict}, blocking`,
+          );
+        }
         deps.stderr(
           `[DuplicationChecker] ${filePath}: BLOCKED — ${blockMatches.length} exact duplicate(s)`,
         );

--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract.ts
@@ -16,6 +16,7 @@ import {
   appendFile as adapterAppendFile,
   ensureDir as adapterEnsureDir,
   readFile as adapterReadFile,
+  writeFile as adapterWriteFile,
   fileExists,
 } from "@hooks/core/adapters/fs";
 import type { AsyncHookContract } from "@hooks/core/contract";
@@ -47,6 +48,8 @@ export interface DuplicationCheckerDeps {
   readFile: (path: string) => string | null;
   exists: (path: string) => boolean;
   appendFile: (path: string, content: string) => void;
+  /** Overwrite a file with new content (used for lock files to prevent corruption). */
+  writeFile: (path: string, content: string) => void;
   ensureDir: (path: string) => void;
   stderr: (msg: string) => void;
   now: () => number;
@@ -76,33 +79,49 @@ function readInferenceConfig(): boolean {
 
 type TriageVerdict = "true_positive" | "false_positive" | "uncertain";
 
+// Content truncation limit — large enough to cover most functions, but bounded.
+// Duplicates beyond this limit are not seen by inference; the checker still blocks them.
+const CONTENT_TRIAGE_LIMIT = 8000;
+
 async function classifyMatches(
   blockMatches: DuplicationMatch[],
   content: string,
   filePath: string,
   deps: DuplicationCheckerDeps,
 ): Promise<TriageVerdict> {
-  const matchDescriptions = blockMatches
-    .map(
-      (m) =>
-        `Function "${m.functionName}" in ${filePath} duplicates "${m.targetName}" in ${m.targetFile} (line ${m.targetLine}, signals: ${m.signals.join(", ")})`,
-    )
-    .join("\n");
+  // Build structured match data — paths/names go into JSON fields, not interpolated strings,
+  // preventing prompt injection via malicious function names or file paths (E8).
+  const matchData = blockMatches.map((m) => ({
+    sourceFunction: m.functionName,
+    sourceFile: filePath,
+    targetFunction: m.targetName,
+    targetFile: m.targetFile,
+    targetLine: m.targetLine,
+    signals: m.signals,
+    // Read target file content so inference can compare both sides (F2)
+    targetContent: (() => {
+      const raw = deps.readFile(m.targetFile);
+      return raw ? raw.slice(0, CONTENT_TRIAGE_LIMIT) : null;
+    })(),
+  }));
 
-  const prompt = [
-    "You are a code duplication triage assistant.",
-    "Determine if the following duplication detection result is a true positive (real duplicate that should be refactored) or a false positive (legitimate code that appears similar but serves a distinct purpose).",
-    "",
-    "Duplication findings:",
-    matchDescriptions,
-    "",
-    "File being written:",
-    "```typescript",
-    content.slice(0, 2000),
-    "```",
-    "",
-    'Respond with JSON only: { "verdict": "true_positive" | "false_positive" | "uncertain", "reason": "brief explanation" }',
-  ].join("\n");
+  // Structured payload — file content is placed in a clearly delimited JSON field,
+  // not interpolated into the instruction text, so injected instructions in the
+  // content cannot escape the data boundary (E1).
+  const payload = JSON.stringify(
+    {
+      task: "duplication_triage",
+      instruction:
+        "Determine if the duplication findings are true positives (real duplicates that should be refactored) or false positives (legitimate code that appears similar but serves a distinct purpose). Respond with the JSON schema specified in responseSchema only.",
+      responseSchema: { verdict: "true_positive | false_positive | uncertain", reason: "string" },
+      findings: matchData,
+      sourceContent: content.slice(0, CONTENT_TRIAGE_LIMIT),
+    },
+    null,
+    2,
+  );
+
+  const prompt = payload;
 
   const result = await tryCatchAsync(
     () => deps.inference({ prompt, level: "fast", timeout: 4000 }),
@@ -156,7 +175,8 @@ function createFalsePositiveReport(
     }
   }
 
-  deps.appendFile(lockPath, String(deps.now()));
+  // Overwrite (not append) so expiry re-check reads only the latest timestamp
+  deps.writeFile(lockPath, String(deps.now()));
 
   const report = {
     ts: new Date(deps.now()).toISOString(),
@@ -180,6 +200,9 @@ const defaultDeps: DuplicationCheckerDeps = {
   exists: (path: string): boolean => fileExists(path),
   appendFile: (path: string, content: string): void => {
     adapterAppendFile(path, content);
+  },
+  writeFile: (path: string, content: string): void => {
+    adapterWriteFile(path, content);
   },
   ensureDir: (path: string): void => {
     adapterEnsureDir(path);
@@ -365,7 +388,6 @@ export const DuplicationCheckerContract: AsyncHookContract<ToolHookInput, Duplic
           `[DuplicationChecker] ${filePath}: BLOCKED — ${blockMatches.length} exact duplicate(s)`,
         );
         return ok({
-          continue: true,
           hookSpecificOutput: {
             hookEventName: "PreToolUse",
             permissionDecision: "deny",

--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
@@ -8,6 +8,7 @@ import {
   DuplicationCheckerContract,
   type DuplicationCheckerDeps,
 } from "@hooks/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.contract";
+import type { InferenceResult } from "@pai/Tools/Inference";
 import { DuplicationIndexBuilderContract } from "@hooks/hooks/DuplicationDetection/DuplicationIndexBuilder/DuplicationIndexBuilder.contract";
 import { buildIndex } from "@hooks/hooks/DuplicationDetection/index-builder-logic";
 import {
@@ -49,6 +50,14 @@ const mockDeps: DuplicationCheckerDeps = {
   stderr: () => {},
   now: () => Date.now(),
   blocking: true,
+  inferenceEnabled: false,
+  inference: async (): Promise<InferenceResult> => ({
+    success: false,
+    output: "",
+    latencyMs: 0,
+    level: "fast" as const,
+  }),
+  issueReporting: false,
 };
 
 function unwrap(result: Result<SyncHookJSONOutput, ResultError>): SyncHookJSONOutput {
@@ -88,7 +97,7 @@ describe("DuplicationCheckerContract", () => {
   // ─── execute() ─────────────────────────────────────────────────────────────
 
   describe("execute()", () => {
-    test("returns continue with no additionalContext when no index exists", () => {
+    test("returns continue with no additionalContext when no index exists", async () => {
       const deps: DuplicationCheckerDeps = {
         ...mockDeps,
         exists: () => false,
@@ -97,12 +106,12 @@ describe("DuplicationCheckerContract", () => {
         `${PAI_HOOKS_ROOT}/hooks/SomeHook/SomeHook.ts`,
         "export function foo() { return 1; }",
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
       expect(output.continue).toBe(true);
       expect(output.hookSpecificOutput).toBeUndefined();
     });
 
-    test("blocks when writing content with 4/4 signal match (exact duplicate)", () => {
+    test("blocks when writing content with 4/4 signal match (exact duplicate)", async () => {
       // cli/commands/install.test.ts contains makeSourceRepo — a function whose
       // body hash matches across lifecycle.integration.test.ts, update.test.ts,
       // and compiled-install.test.ts → hash signal → block.
@@ -123,7 +132,7 @@ describe("DuplicationCheckerContract", () => {
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         realContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
       const hs = output.hookSpecificOutput;
       expect(hs?.hookEventName).toBe("PreToolUse");
       if (hs && hs.hookEventName === "PreToolUse") {
@@ -132,7 +141,7 @@ describe("DuplicationCheckerContract", () => {
       }
     });
 
-    test("logs but does not block for 2-3 signal matches", () => {
+    test("logs but does not block for 2-3 signal matches", async () => {
       // Craft content with a function that shares name+sig but NOT body hash
       // with existing functions (2/4 signals = log only, not block)
       const partialMatchContent = `
@@ -153,11 +162,11 @@ export function makeDeps(x: string): Record<string, unknown> {
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         partialMatchContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
       expect(output.continue).toBe(true);
     });
 
-    test("returns continue for genuinely unique content", () => {
+    test("returns continue for genuinely unique content", async () => {
       // Use a truly unique signature to avoid sig+body matches
       const uniqueContent = `
 export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: boolean, deltaEpsilon: Map<string, number>): [string, boolean] {
@@ -177,11 +186,11 @@ export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: bo
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         uniqueContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
       expect(output.continue).toBe(true);
     });
 
-    test("block reason lists duplicate targets", () => {
+    test("block reason lists duplicate targets", async () => {
       const realContent = require("node:fs").readFileSync(
         `${PAI_HOOKS_ROOT}/cli/commands/install.test.ts`,
         "utf-8",
@@ -198,7 +207,7 @@ export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: bo
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         realContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
       const hs = output.hookSpecificOutput;
       expect(hs?.hookEventName).toBe("PreToolUse");
       if (hs && hs.hookEventName === "PreToolUse") {
@@ -208,7 +217,7 @@ export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: bo
       }
     });
 
-    test("blocks regardless of index age (no staleness bypass)", () => {
+    test("blocks regardless of index age (no staleness bypass)", async () => {
       const realContent = require("node:fs").readFileSync(
         `${PAI_HOOKS_ROOT}/cli/commands/install.test.ts`,
         "utf-8",
@@ -218,14 +227,14 @@ export function veryUniquelyNamedXyz99Function(alphaOmega: string, betaGamma: bo
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         realContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, mockDeps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, mockDeps));
       const hs = output.hookSpecificOutput;
       expect(hs?.hookEventName).toBe("PreToolUse");
       if (hs && hs.hookEventName === "PreToolUse") {
         expect(hs.permissionDecision).toBe("deny");
       }
     });
-    test("injects additionalContext when function matches a known pattern", () => {
+    test("injects additionalContext when function matches a known pattern", async () => {
       const patternContent = `
 function makeDeps(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
   return { stderr: () => {}, now: () => Date.now(), ...overrides };
@@ -268,7 +277,7 @@ function makeDeps(overrides: Partial<Record<string, unknown>> = {}): Record<stri
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         patternContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
       expect(output.continue).toBe(true);
       const hs = output.hookSpecificOutput;
       expect(hs?.hookEventName).toBe("PreToolUse");
@@ -279,7 +288,7 @@ function makeDeps(overrides: Partial<Record<string, unknown>> = {}): Record<stri
       }
     });
 
-    test("no pattern advisory for unique function names", () => {
+    test("no pattern advisory for unique function names", async () => {
       const uniqueContent = `
 function superUniqueSpecialFunction123(): string {
   return "unique";
@@ -319,12 +328,12 @@ function superUniqueSpecialFunction123(): string {
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         uniqueContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
       expect(output.continue).toBe(true);
       expect(output.hookSpecificOutput).toBeUndefined();
     });
 
-    test("continues instead of blocking when blocking config is false", () => {
+    test("continues instead of blocking when blocking config is false", async () => {
       const realContent = require("node:fs").readFileSync(
         `${PAI_HOOKS_ROOT}/cli/commands/install.test.ts`,
         "utf-8",
@@ -339,8 +348,98 @@ function superUniqueSpecialFunction123(): string {
         `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
         realContent,
       );
-      const output = unwrap(DuplicationCheckerContract.execute(input, deps));
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
       expect(output.continue).toBe(true);
+    });
+  });
+
+  // ─── false-positive triage ──────────────────────────────────────────────────
+
+  describe("false-positive triage", () => {
+    function makeBlockingInput() {
+      const realContent = require("node:fs").readFileSync(
+        `${PAI_HOOKS_ROOT}/cli/commands/install.test.ts`,
+        "utf-8",
+      ) as string;
+      return {
+        input: makeWriteInput(
+          `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
+          realContent,
+        ),
+      };
+    }
+
+    test("inferenceEnabled false — still blocks on duplicate match", async () => {
+      const { input } = makeBlockingInput();
+      const deps: DuplicationCheckerDeps = {
+        ...mockDeps,
+        inferenceEnabled: false,
+      };
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
+      const hs = output.hookSpecificOutput;
+      expect(hs?.hookEventName).toBe("PreToolUse");
+      if (hs && hs.hookEventName === "PreToolUse") {
+        expect(hs.permissionDecision).toBe("deny");
+      }
+    });
+
+    test("false_positive verdict — returns continue with additionalContext", async () => {
+      const { input } = makeBlockingInput();
+      const deps: DuplicationCheckerDeps = {
+        ...mockDeps,
+        inferenceEnabled: true,
+        inference: async (): Promise<InferenceResult> => ({
+          success: true,
+          output: JSON.stringify({ verdict: "false_positive", reason: "distinct purpose" }),
+          latencyMs: 50,
+          level: "fast" as const,
+        }),
+      };
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
+      expect(output.continue).toBe(true);
+      const hs = output.hookSpecificOutput;
+      expect(hs?.hookEventName).toBe("PreToolUse");
+      if (hs && hs.hookEventName === "PreToolUse") {
+        expect(hs.permissionDecision).toBeUndefined();
+        expect(hs.additionalContext).toContain("false positive");
+      }
+    });
+
+    test("true_positive verdict — blocks with deny", async () => {
+      const { input } = makeBlockingInput();
+      const deps: DuplicationCheckerDeps = {
+        ...mockDeps,
+        inferenceEnabled: true,
+        inference: async (): Promise<InferenceResult> => ({
+          success: true,
+          output: JSON.stringify({ verdict: "true_positive", reason: "exact duplicate" }),
+          latencyMs: 50,
+          level: "fast" as const,
+        }),
+      };
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
+      const hs = output.hookSpecificOutput;
+      expect(hs?.hookEventName).toBe("PreToolUse");
+      if (hs && hs.hookEventName === "PreToolUse") {
+        expect(hs.permissionDecision).toBe("deny");
+      }
+    });
+
+    test("inference failure — fails safe with deny", async () => {
+      const { input } = makeBlockingInput();
+      const deps: DuplicationCheckerDeps = {
+        ...mockDeps,
+        inferenceEnabled: true,
+        inference: async (): Promise<InferenceResult> => {
+          throw new Error("inference service unavailable");
+        },
+      };
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
+      const hs = output.hookSpecificOutput;
+      expect(hs?.hookEventName).toBe("PreToolUse");
+      if (hs && hs.hookEventName === "PreToolUse") {
+        expect(hs.permissionDecision).toBe("deny");
+      }
     });
   });
 });

--- a/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
+++ b/hooks/DuplicationDetection/DuplicationChecker/DuplicationChecker.test.ts
@@ -46,6 +46,7 @@ const mockDeps: DuplicationCheckerDeps = {
   readFile: (path) => require("node:fs").readFileSync(path, "utf-8") as string,
   exists: (path) => require("node:fs").existsSync(path) as boolean,
   appendFile: () => {},
+  writeFile: () => {},
   ensureDir: () => {},
   stderr: () => {},
   now: () => Date.now(),
@@ -440,6 +441,129 @@ function superUniqueSpecialFunction123(): string {
       if (hs && hs.hookEventName === "PreToolUse") {
         expect(hs.permissionDecision).toBe("deny");
       }
+    });
+
+    test("uncertain verdict — falls through to block with deny (F4)", async () => {
+      const { input } = makeBlockingInput();
+      const deps: DuplicationCheckerDeps = {
+        ...mockDeps,
+        inferenceEnabled: true,
+        inference: async (): Promise<InferenceResult> => ({
+          success: true,
+          output: JSON.stringify({ verdict: "uncertain", reason: "could not determine" }),
+          latencyMs: 50,
+          level: "fast" as const,
+        }),
+      };
+      const output = unwrap(await DuplicationCheckerContract.execute(input, deps));
+      const hs = output.hookSpecificOutput;
+      expect(hs?.hookEventName).toBe("PreToolUse");
+      if (hs && hs.hookEventName === "PreToolUse") {
+        expect(hs.permissionDecision).toBe("deny");
+      }
+    });
+  });
+
+  // ─── false-positive reporting ───────────────────────────────────────────────
+
+  describe("false-positive reporting", () => {
+    function makeBlockingInput() {
+      const realContent = require("node:fs").readFileSync(
+        `${PAI_HOOKS_ROOT}/cli/commands/install.test.ts`,
+        "utf-8",
+      ) as string;
+      return {
+        input: makeWriteInput(
+          `${PAI_HOOKS_ROOT}/hooks/DuplicationDetection/SomeNewHook.ts`,
+          realContent,
+        ),
+      };
+    }
+
+    test("createFalsePositiveReport writes lock and report when issueReporting is true (F3)", async () => {
+      const { input } = makeBlockingInput();
+      const written: Array<{ path: string; content: string }> = [];
+      const overwritten: Array<{ path: string; content: string }> = [];
+
+      const deps: DuplicationCheckerDeps = {
+        ...mockDeps,
+        inferenceEnabled: true,
+        issueReporting: true,
+        exists: (path) => {
+          // Pretend lock file does not exist so reporting runs
+          if (path.endsWith(".lock")) return false;
+          return (require("node:fs").existsSync(path) as boolean);
+        },
+        appendFile: (path, content) => {
+          written.push({ path, content });
+        },
+        writeFile: (path, content) => {
+          overwritten.push({ path, content });
+        },
+        inference: async (): Promise<InferenceResult> => ({
+          success: true,
+          output: JSON.stringify({ verdict: "false_positive", reason: "distinct purpose" }),
+          latencyMs: 50,
+          level: "fast" as const,
+        }),
+      };
+
+      await DuplicationCheckerContract.execute(input, deps);
+
+      // Lock file must be written (overwrite, not append)
+      const lockWrite = overwritten.find((w) => w.path.endsWith(".lock"));
+      expect(lockWrite).toBeDefined();
+      expect(Number(lockWrite!.content)).toBeGreaterThan(0);
+
+      // Report JSON must be appended
+      const reportAppend = written.find((w) => w.path.endsWith(".report.json"));
+      expect(reportAppend).toBeDefined();
+      const report = JSON.parse(reportAppend!.content) as {
+        ts: string;
+        file: string;
+        matches: Array<{ fn: string; target: string; signals: string[] }>;
+      };
+      expect(report.file).toContain("SomeNewHook.ts");
+      expect(Array.isArray(report.matches)).toBe(true);
+    });
+
+    test("createFalsePositiveReport skips when lock is fresh (F3)", async () => {
+      const { input } = makeBlockingInput();
+      const written: Array<{ path: string }> = [];
+
+      const freshTs = String(Date.now()); // within 7-day window
+
+      const deps: DuplicationCheckerDeps = {
+        ...mockDeps,
+        inferenceEnabled: true,
+        issueReporting: true,
+        exists: (path) => {
+          if (path.endsWith(".lock")) return true;
+          return (require("node:fs").existsSync(path) as boolean);
+        },
+        readFile: (path) => {
+          if (path.endsWith(".lock")) return freshTs;
+          return (require("node:fs").readFileSync(path, "utf-8") as string);
+        },
+        appendFile: (path) => {
+          written.push({ path });
+        },
+        writeFile: (path) => {
+          written.push({ path });
+        },
+        inference: async (): Promise<InferenceResult> => ({
+          success: true,
+          output: JSON.stringify({ verdict: "false_positive", reason: "distinct purpose" }),
+          latencyMs: 50,
+          level: "fast" as const,
+        }),
+      };
+
+      await DuplicationCheckerContract.execute(input, deps);
+
+      // No lock or report writes should happen — fresh lock suppresses reporting
+      const reportWrites = written.filter((w) => w.path.includes("fp-reports"));
+      expect(reportWrites).toHaveLength(0);
     });
   });
 });

--- a/hooks/DuplicationDetection/DuplicationChecker/IDEA.md
+++ b/hooks/DuplicationDetection/DuplicationChecker/IDEA.md
@@ -16,7 +16,10 @@ A pre-write hook that extracts functions from incoming code and compares them ag
 2. Extract all function declarations from the new content.
 3. For each function, compute four signals: exact body hash, function name, parameter signature hash, and normalized body hash (ignoring variable names).
 4. Query the duplication index for matches across all four signals.
-5. If 4/4 signals match or the exact body hash matches — block the write with "this function already exists at [location]."
+5. If 4/4 signals match or the exact body hash matches — optionally run inference triage before blocking:
+   - If inference classifies the match as a false positive, allow the write with an advisory explaining the override.
+   - If inference classifies it as a true positive, uncertain, or fails — block the write (fail-safe).
+   - If inference is disabled (default) — block immediately with "this function already exists at [location]."
 6. If 2-3 signals match — inject an advisory warning suggesting the author check the similar function.
 7. If 0-1 signals match — pass silently.
 

--- a/hooks/DuplicationDetection/DuplicationChecker/doc.md
+++ b/hooks/DuplicationDetection/DuplicationChecker/doc.md
@@ -51,14 +51,21 @@ It does **not** fire when:
 5. Extracts function signatures from the content using SWC parser
 6. Compares extracted functions against the index using `checkFunctions`
 7. Logs all checks to `checker.jsonl` with branch metadata
-8. At 4/4 signals and blocking enabled: returns block with per-match guidance — "Import it from X" when the target is a canonical source file, "Reuse the existing function from X or extract both to a shared module" otherwise
-9. At 2-3/4 signals: logs finding, returns continue
+8. At 4/4 signals and blocking enabled: optionally runs inference triage (`classifyMatches`) when `inferenceEnabled: true`
+   - `false_positive` verdict → returns continue with `additionalContext` explaining the override; optionally writes a report to `/tmp/pai/duplication/fp-reports/` when `issueReporting: true`
+   - `true_positive`, `uncertain`, or inference failure → falls through to deny (fail-safe)
+9. At 4/4 signals, blocking enabled, triage not triggered: returns block with per-match guidance — "Import it from X" when the target is a canonical source file, "Reuse the existing function from X or extract both to a shared module" otherwise
+10. At 2-3/4 signals: logs finding, returns continue
 
 ```typescript
-// Tiered response logic
-const blockMatches = matches.filter((m) => m.signals.length >= BLOCK_THRESHOLD);
-
+// Block path with optional inference triage
 if (blockMatches.length > 0 && deps.blocking) {
+  if (deps.inferenceEnabled) {
+    const verdict = await classifyMatches(blockMatches, content, filePath, deps);
+    if (verdict === "false_positive") {
+      return ok({ continue: true, hookSpecificOutput: { hookEventName: "PreToolUse", additionalContext: "..." } });
+    }
+  }
   return ok({
     continue: true,
     hookSpecificOutput: {
@@ -148,7 +155,7 @@ Pattern detection thresholds are set in `hookConfig.duplicationChecker` in `sett
 
 | Dependency | Type | Purpose |
 | --- | --- | --- |
-| `result` | core | `ok()` for Result-based returns |
+| `result` | core | `ok()`, `tryCatchAsync()` for Result-based returns and safe async boundaries |
 | `fs` | adapter | `readFile`, `fileExists`, `readJson`, `appendFile`, `ensureDir` |
 | `lib/paths` | lib | `getSettingsPath` for reading hookConfig |
 | `lib/tool-input` | lib | `getFilePath`, `getWriteContent` for extracting tool input fields |
@@ -157,3 +164,4 @@ Pattern detection thresholds are set in `hookConfig.duplicationChecker` in `sett
 | `lib/narrative-reader` | lib | `pickNarrative` for severity-tiered block message openers |
 | `DuplicationChecker.narrative.jsonl` | data | 9 agent narratives (3 per severity tier) with DRY/WET theming |
 | `inspector.ts` | cli | State inspector for `paih inspect DuplicationChecker` — reads index, returns summary/raw/JSON views |
+| `@pai/Tools/Inference` (injected) | stub | Inference function for false-positive triage — injected via `deps.inference`; disabled by default (`inferenceEnabled: false`) |

--- a/hooks/DuplicationDetection/DuplicationChecker/hook.json
+++ b/hooks/DuplicationDetection/DuplicationChecker/hook.json
@@ -2,7 +2,7 @@
   "name": "DuplicationChecker",
   "group": "DuplicationDetection",
   "event": "PreToolUse",
-  "description": "Tiered duplication guard: 1/4 ignore, 2-3/4 log, 4/4 block (configurable via hookConfig.duplicationChecker.blocking)",
+  "description": "Tiered duplication guard: 1/4 ignore, 2-3/4 log, 4/4 block with optional inference triage to suppress false positives (configurable via hookConfig.duplicationChecker.blocking and inferenceEnabled)",
   "schemaVersion": 1,
   "tags": ["quality", "duplication"],
   "presets": []


### PR DESCRIPTION
## Summary

- Migrates `DuplicationCheckerContract` from `SyncHookContract` to `AsyncHookContract` so the block path can await inference
- Adds optional inference triage (`classifyMatches`) on block-worthy matches — `false_positive` allows the write with `additionalContext`; `true_positive`/`uncertain`/failure falls through to deny (fail-safe)
- Adds optional rate-limited false-positive reporting to `/tmp/pai/duplication/fp-reports/` (opt-in via `issueReporting: false` default)
- All existing tests migrated to async; 4 new triage tests added; inference disabled by default (`inferenceEnabled: false`)

## Acceptance criteria

- [x] Existing block behavior preserved when `inferenceEnabled: false` (default)
- [x] Existing tests pass with async migration (`await` added)
- [x] False positive → continue with `additionalContext`
- [x] True positive → `permissionDecision: "deny"`
- [x] Inference failure → `permissionDecision: "deny"` (fail-safe)
- [x] `tsc --noEmit` exits 0 (no new errors introduced)
- [x] Rate-limit prevents duplicate reports (7-day TTL lock file)
- [x] Issue creation is opt-in and disabled by default

## Test plan

- `bun test hooks/DuplicationDetection/DuplicationChecker` → 24 pass, 0 fail
- `bun x tsc --noEmit` → only pre-existing errors in `DocObligationStateMachine.ts` (unrelated)

<img src="https://github.com/user-attachments/assets/08e4e5de-c220-46c6-968d-1976411654b3" alt="🍁" width="16" height="16"> Maple